### PR TITLE
refactor(catalog): update search response properties

### DIFF
--- a/cypress/e2e/specs/catalog.spec.ts
+++ b/cypress/e2e/specs/catalog.spec.ts
@@ -13,7 +13,23 @@ const mockServiceSearchQuery = (searchQuery: string) => {
     .filter((data) =>
       searchQuery !== '' ? JSON.stringify(data).includes(searchQuery) : true
     )
-    .map(([name, versions, id]) => ({ index: 'product-catalog', source: { description: '', has_documentation: false, created_at: '', updated_at: '', name, versions, id } }))
+    .map(([name, versions, id]) => ({
+      index: 'product-catalog',
+      source: {
+        id,
+        description: '',
+        document_count: 0,
+        created_at: '',
+        updated_at: '',
+        name,
+        version_count: versions.length,
+        latest_version: {
+          name: versions[0].name,
+          id: versions[0].id
+        }
+      }
+    }))
+
   const responseBody: SearchResults = {
     data: searchResults,
     meta: {
@@ -108,7 +124,7 @@ describe('Catalog', () => {
 
     it('renders the documentation link for catalog item', () => {
       cy.mockPrivatePortal()
-      cy.mockProductsCatalog(1, [{ description: 'great description', has_documentation: true }])
+      cy.mockProductsCatalog(1, [{ description: 'great description', document_count: 2 }])
       cy.visit('/')
       cy.get('.catalog-item .link').contains('Documentation').should('exist')
     })
@@ -138,7 +154,7 @@ describe('Catalog', () => {
     })
     it('renders the documentation link for catalog item ', () => {
       cy.mockPrivatePortal()
-      cy.mockProductsCatalog(1, [{ description: 'great description', has_documentation: true }])
+      cy.mockProductsCatalog(1, [{ description: 'great description', document_count: 1 }])
 
       cy.visit('/')
 
@@ -158,22 +174,11 @@ describe('Catalog', () => {
 
     it('displays most recent created_at version', () => {
       cy.mockProductsCatalog(1, [{
-        versions: [
-          {
-            created_at: '2022-03-23T12:41:09.371Z',
-            updated_at: '2022-03-23T12:41:09.371Z',
-            id: '6159b9be-bfbc-4f30-bd22-df720f6dcf90',
-            name: 'v4',
-            deprecated: false
-          },
-          {
-            created_at: '2022-03-23T11:46:35.613Z',
-            updated_at: '2022-03-23T11:46:35.613Z',
-            id: 'b820d3eb-5b70-47e5-8d97-9436a8021282',
-            name: 'v1-beta',
-            deprecated: false
-          }
-        ]
+        version_count: 2,
+        latest_version: {
+          id: '6159b9be-bfbc-4f30-bd22-df720f6dcf90',
+          name: 'v4'
+        }
       }])
 
       cy.visit('/')
@@ -188,22 +193,11 @@ describe('Catalog', () => {
 
     it('displays most recent created_at regardless of version name', () => {
       cy.mockProductsCatalog(1, [{
-        versions: [
-          {
-            created_at: '2022-03-23T12:41:09.371Z',
-            updated_at: '2022-03-23T12:41:09.371Z',
-            id: '6159b9be-bfbc-4f30-bd22-df720f6dcf90',
-            name: 'v4',
-            deprecated: false
-          },
-          {
-            created_at: '2022-03-24T11:46:35.613Z',
-            updated_at: '2022-03-24T11:46:35.613Z',
-            id: 'b820d3eb-5b70-47e5-8d97-9436a8021282',
-            name: 'v1-beta',
-            deprecated: false
-          }
-        ]
+        version_count: 2,
+        latest_version: {
+          id: '6159b9be-bfbc-4f30-bd22-df720f6dcf90',
+          name: 'v4'
+        }
       }])
       cy.visit('/')
       cy.get('[data-testid="view-switcher"]:not(:disabled)')

--- a/cypress/e2e/specs/catalog.spec.ts
+++ b/cypress/e2e/specs/catalog.spec.ts
@@ -204,7 +204,7 @@ describe('Catalog', () => {
         .click()
         .get('.k-table tbody tr:first-child td:nth-child(3)')
         .should('have.length', 1)
-        .contains('v1-beta')
+        .contains('v4')
       cy.get('[data-testid="view-switcher"]:not(:disabled)').click()
     })
   })

--- a/cypress/e2e/support/utils/generateProducts.ts
+++ b/cypress/e2e/support/utils/generateProducts.ts
@@ -1,4 +1,4 @@
-import { ProductCatalogIndexSource, ProductVersion, SearchResultsDataInner } from '@kong/sdk-portal-js'
+import { ProductCatalogIndexSource, ProductCatalogIndexSourceLatestVersion, ProductVersion, SearchResultsDataInner } from '@kong/sdk-portal-js'
 
 export const generateProducts = (count: number, options: Partial<ProductCatalogIndexSource>[] = []): SearchResultsDataInner[] => {
   const productsList: SearchResultsDataInner[] = []
@@ -12,10 +12,9 @@ export const generateProducts = (count: number, options: Partial<ProductCatalogI
         updated_at: '2020-08-25T16:14:52.450Z',
         name: 'barAPI' + i,
         description: undefined,
-        has_documentation: false,
-        versions: [
-          generateVersion(i)
-        ],
+        document_count: 0,
+        latest_version: generateLatestVersion(i),
+        version_count: 1,
         ...options[i] || {}
       }
     })
@@ -24,13 +23,9 @@ export const generateProducts = (count: number, options: Partial<ProductCatalogI
   return productsList
 }
 
-function generateVersion (i: number):ProductVersion {
+function generateLatestVersion (i: number): ProductCatalogIndexSourceLatestVersion {
   return {
     id: 'a41041e4-d324-43c8-977a-ad68f1839751' + i,
-    created_at: '2020-08-25T16:14:54.564Z',
-    updated_at: '2020-08-25T16:14:54.564Z',
-    name: 'v2',
-    deprecated: false,
-    registration_configs: []
+    name: 'v2'
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@kong-ui-public/spec-renderer": "^0.7.4",
     "@kong/kong-auth-elements": "2.0.0",
     "@kong/kongponents": "8.60.1",
-    "@kong/sdk-portal-js": "0.0.1-beta.19",
+    "@kong/sdk-portal-js": "0.0.1-beta.20",
     "@xstate/vue": "^2.0.0",
     "axios": "0.27.2",
     "date-fns": "2.29.3",

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -52,7 +52,7 @@ import { PropType, defineComponent } from 'vue'
 import EmptyState from '../assets/catalog-empty-state.svg'
 import CatalogCardList from './CatalogCardList.vue'
 import CatalogTableList from './CatalogTableList.vue'
-import { CustomProduct, useI18nStore } from '@/stores'
+import { CatalogItemModel, useI18nStore } from '@/stores'
 
 export default defineComponent({
   name: 'Catalog',
@@ -63,7 +63,7 @@ export default defineComponent({
   },
   props: {
     services: {
-      type: Array as PropType<CustomProduct[]>,
+      type: Array as PropType<CatalogItemModel[]>,
       default: () => []
     },
     cardsPerPage: {

--- a/src/components/CatalogCardList.vue
+++ b/src/components/CatalogCardList.vue
@@ -6,7 +6,7 @@
         :key="service.id + index"
         class="catalog-item"
         :service="service"
-        :has-documentation="service.hasDocumentation"
+        :has-documentation="service.documentCount > 0"
         :loading="loading"
       />
     </div>
@@ -24,7 +24,7 @@
 import CatalogItem from './CatalogItem.vue'
 import PaginationBar from './PaginationBar.vue'
 import { PropType } from 'vue'
-import { CustomProduct } from '@/stores'
+import { CatalogItemModel } from '@/stores'
 
 export default {
   name: 'CatalogCardList',
@@ -34,7 +34,7 @@ export default {
   },
   props: {
     services: {
-      type: Array as PropType<CustomProduct[]>,
+      type: Array as PropType<CatalogItemModel[]>,
       default: () => []
     },
     pageSize: {

--- a/src/components/CatalogItem.vue
+++ b/src/components/CatalogItem.vue
@@ -47,7 +47,7 @@
                 background-color="var(--section_colors-accent)"
                 class="service-version"
               >
-                {{ version }}
+                {{ version.name }}
               </KBadge>
             </template>
           </span>
@@ -73,7 +73,7 @@
             </template>
           </div>
           <div
-            v-if="service.hasDocumentation"
+            v-if="service.documentCount"
             class="details-item"
           >
             <template v-if="loading">
@@ -101,14 +101,14 @@
 </template>
 
 <script lang="ts">
-import { CustomProduct } from '@/stores'
+import { CatalogItemModel } from '@/stores'
 import { PropType } from 'vue'
 
 export default {
   name: 'CatalogItem',
   props: {
     service: {
-      type: Object as PropType<CustomProduct>,
+      type: Object as PropType<CatalogItemModel>,
       default: () => {}
     },
     loading: {
@@ -121,10 +121,10 @@ export default {
   },
   computed: {
     version () {
-      return this.service.versions[this.service.versions.length - 1]
+      return this.service.latestVersion
     },
     versionLabel () {
-      return this.service.versions.length === 1 ? 'Version: ' : 'Versions: '
+      return this.service.versionCount === 1 ? 'Version: ' : 'Versions: '
     }
   }
 }

--- a/src/components/CatalogTableList.vue
+++ b/src/components/CatalogTableList.vue
@@ -13,15 +13,15 @@
       <template #title="{rowValue}">
         {{ rowValue }}
       </template>
-      <template #versions="{row}">
+      <template #latestVersion="{row}">
         <div>
           <KBadge
-            v-if="row.versions.length > 0"
+            v-if="row.latestVersion"
             color="var(--text_colors-secondary)"
             background-color="var(--section_colors-accent)"
             class="service-version"
           >
-            {{ row.versions[row.versions.length - 1] }}
+            {{ row.latestVersion.name }}
           </KBadge>
         </div>
       </template>
@@ -33,7 +33,7 @@
           Specification
         </router-link>
         <router-link
-          v-if="row.hasDocumentation"
+          v-if="row.documentCount"
           :to="{ name: 'api-documentation-page', params: { service_package: row.id } }"
           class="link"
         >
@@ -91,7 +91,7 @@ export default defineComponent({
       tableHeaders: [
         { label: 'Title', key: 'title' },
         { label: 'Description', key: 'description' },
-        { label: 'Latest Version', key: 'versions' },
+        { label: 'Latest Version', key: 'latestVersion' },
         { label: 'Details', key: 'links' }
       ]
     }

--- a/src/stores/product.ts
+++ b/src/stores/product.ts
@@ -6,12 +6,13 @@ import { ref } from 'vue'
 export interface ProductWithVersions extends Product {
   versions: ProductVersion[]
 }
-export interface CustomProduct {
+export interface CatalogItemModel {
   id: string;
   title: string;
-  versions: string[];
+  latestVersion: null|{ name: string; id: string}
   description: string;
-  hasDocumentation: boolean;
+  documentCount: number;
+  versionCount: number;
 }
 
 export type CustomOperation = Operation & {tag?: string}

--- a/src/views/ServiceShell.vue
+++ b/src/views/ServiceShell.vue
@@ -118,7 +118,7 @@ async function fetchDocumentTree () {
   }
 }
 
-function initactiveProductVersionId () {
+function initActiveProductVersionId () {
   if (!product.value) {
     return
   }
@@ -193,7 +193,7 @@ onMounted(async () => {
   setActiveDocumentSlug()
   await fetchServicePackage()
   await fetchDocumentTree()
-  initactiveProductVersionId()
+  initActiveProductVersionId()
 })
 
 watch(() => serviceVersionParam.value, () => {
@@ -201,7 +201,7 @@ watch(() => serviceVersionParam.value, () => {
     productStore.setActiveProductVersionId(serviceVersionParam.value)
   }
 
-  initactiveProductVersionId()
+  initActiveProductVersionId()
 })
 
 // This ensures deselection of operations in the sidebar when the user navigates away from the spec page
@@ -214,7 +214,7 @@ watch(() => activeProductVersionId.value, (newVal, oldVal) => {
     onSwitchVersion()
   }
 
-  if (!product.value?.versions) {
+  if (!product.value?.version_count) {
     return
   }
 

--- a/src/views/Services.vue
+++ b/src/views/Services.vue
@@ -56,9 +56,8 @@
 import { defineComponent, ref, onBeforeMount } from 'vue'
 import usePortalApi from '@/hooks/usePortalApi'
 import Catalog from '@/components/Catalog.vue'
-import { sortBy, SortOrder, SortType } from '@/helpers/sortBy'
 import { debounce } from '@/helpers/debounce'
-import { useI18nStore, CustomProduct } from '@/stores'
+import { useI18nStore, CatalogItemModel } from '@/stores'
 
 export default defineComponent({
   name: 'Services',
@@ -70,7 +69,7 @@ export default defineComponent({
     const primary_header = ref('')
     const cardsPerPage = ref(12)
     const searchString = ref('')
-    const services = ref<CustomProduct[]>([])
+    const services = ref<CatalogItemModel[]>([])
     const totalCount = ref<number>(undefined)
     const loading = ref<boolean>(null)
     const searchTriggered = ref<boolean>(false)
@@ -136,16 +135,13 @@ export default defineComponent({
           const { data: sources, meta } = portalEntities
 
           services.value = sources.map(({ source }) => {
-            const versions = [...source.versions]
-              .sort(sortBy('created_at', SortOrder.ASC, SortType.DATE))
-              .map(version => version.name)
-
             return {
               id: source.id,
               title: source.name,
-              versions,
+              latestVersion: source.latest_version,
               description: source.description,
-              hasDocumentation: source.has_documentation
+              documentCount: source.document_count,
+              versionCount: source.version_count
             }
           })
           totalCount.value = meta.page.total

--- a/yarn.lock
+++ b/yarn.lock
@@ -926,10 +926,12 @@
     v-calendar "^3.0.0-alpha.8"
     vue-draggable-next "^2.1.1"
 
-"@kong/sdk-portal-js@0.0.1-beta.19":
-  version "0.0.1-beta.19"
-  resolved "https://registry.yarnpkg.com/@kong/sdk-portal-js/-/sdk-portal-js-0.0.1-beta.19.tgz#8b2a73d1b214ff0faa128cd7b60387cab7713672"
-  integrity sha512-d4fpn2c65rnnT2wop6byrNon6H0w7gDtt0nTNHtwQsYaW9pQdfwsRAOVXrquqJ3pRmEf4Dr9bYbfHXNYCJhM7w==
+"@kong/sdk-portal-js@0.0.1-beta.20":
+  version "0.0.1-beta.20"
+  resolved "https://registry.yarnpkg.com/@kong/sdk-portal-js/-/sdk-portal-js-0.0.1-beta.20.tgz#fce868f80f0597c028a4de0f06a7e03ff0c1d492"
+  integrity sha512-UYYByKvHIxq2nHjdCzYUDvXCy6pbXBYkBrueWQjA9PKOsLaIDWvCwtcLEa1oYo+aJEp3VOPA6AlvG6mduIrpJQ==
+  dependencies:
+    axios "1.4.0"
 
 "@kong/swagger-ui-kong-theme-universal@^4.1.6":
   version "4.1.6"
@@ -2018,6 +2020,15 @@ axios@0.27.2, axios@^0.27.2:
   dependencies:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
+
+axios@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axios@=1.3.4:
   version "1.3.4"


### PR DESCRIPTION
Recent changes to Portal API v2 beta made the following adjustments:
- Removed `versions` and `has_documentation` from each search result
- Added `latest_version`, `version_count`, and `document_count` to each result