### PR TITLE
style: wrap text in catalog table view for long descriptions

### DIFF
--- a/src/components/CatalogTableList.vue
+++ b/src/components/CatalogTableList.vue
@@ -110,6 +110,7 @@ export default defineComponent({
     tbody {
       td {
         color: var(--text_colors-secondary);
+
         &:nth-of-type(1) {
           min-width: 120px;
           color: var(--text_colors-headings);
@@ -117,6 +118,7 @@ export default defineComponent({
         &:nth-of-type(2) {
           width: auto;
           max-width: 65ch;
+          white-space: normal;
         }
       }
     }


### PR DESCRIPTION
Wraps the text in catalog list table view when description of a product is long.
<img width="1428" alt="Screenshot 2023-05-29 at 10 31 50 AM" src="https://github.com/Kong/konnect-portal/assets/40131297/0ac96757-d944-454c-8032-e21ae34568e1">
