### PR TITLE
fix: remove legacy endpoints

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -82,14 +82,6 @@ export default ({ command, mode }) => {
             mutateCookieAttributes(proxy)
           }
         },
-        '^/portal_api': {
-          target: portalApiUrl,
-          changeOrigin: true,
-          configure: (proxy, options) => {
-            mutateCookieAttributes(proxy)
-            setHostHeader(proxy)
-          }
-        },
         '^/api': {
           target: portalApiUrl,
           changeOrigin: true,


### PR DESCRIPTION
Those endpoints are legacy and do not need to be in the proxy config