### PR TITLE
docs: Add about and configuration documentation

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,19 @@
+# About the Example Konnect Portal Application
+
+This page explains how the example Konnect portal application works, how you can customize it, and how to configure UI testing with Cypress.
+
+## How the example application works
+
+<!-- depending on how much info you have, this could be one or multiple sections with some tech details users would need to know before using
+this app -->
+
+## Customize the example Konnect portal application
+
+<!-- This would probably be a numbered list with some directions on how users can customize the settings -->
+
+For more information about what parameters you can configure, see [Configuration Reference](/docs/reference.md).
+
+## Configure automated UI testing with Cypress
+
+<!-- I wasn't sure if this was something users would have to configure at all, but I do think they should have some info about how this works.
+Feel free to remove or rename this section -->

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,10 @@
+# Configuration Reference
+
+This page explains the different parameters you can configure and what they do.
+
+| Parameter      | Notes |
+| --------- | ---------- |
+|Example | Example |
+|Example | Example |
+
+<!-- Maybe have different h2 sections with separate tables if there's a lot of different parameters? Like ones for localization, others for UI customization, etc. -->


### PR DESCRIPTION
Explanation of changes:
- I created docs in the Konnect docs page that explain how to use the self-hosted portal and some information about it (https://github.com/Kong/docs.konghq.com/pull/5631), and I was also asked to help create some docs for the OSS repo. 
- The purpose of these docs is to explain the specifics of the **example application**, such as how it works, the default settings, and specifically how people can use the different configuration parameters to customize the example application to suit their organization.
- I don't understand the tech that well, so I created some templates that your team can further edit and add to. I'm happy to do any revisions/copy edits of content you add and work with anyone to flesh these out.
