### PR TITLE
fix: kauth baseUrl handling

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -8,7 +8,9 @@ import PortalV2ApiService from '@/services/PortalV2ApiService'
  * properly resolve within container applications, especially when called from nested routes
  */
 
-export const authApiBaseUrl = import.meta.env.DEV ? '/kauth' : new URL('/kauth', import.meta.env.VITE_PORTAL_API_URL).href
+const kauthBaseUrl = import.meta.env.VITE_PORTAL_API_URL && import.meta.env.VITE_PORTAL_API_URL !== '/' ? import.meta.env.VITE_PORTAL_API_URL : window.location.hostname
+
+export const authApiBaseUrl = import.meta.env.DEV ? '/kauth' : new URL('/kauth', kauthBaseUrl).href
 
 export const baseUrl = import.meta.env.DEV ? '/' : import.meta.env.VITE_PORTAL_API_URL
 


### PR DESCRIPTION
In the case of routing the API URL on `/` this function fails.
```js
new URL('/kauth', import.meta.env.VITE_PORTAL_API_URL).href
```

This pull-request adresses the issue and fallsback on window hostname.