### PR TITLE
ci: remove caching for cypress tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,11 +36,6 @@ jobs:
         containers: [1, 2, 3]
     steps:
       - uses: actions/checkout@v3
-      - name: node modules cache
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: ${{ hashFiles('.nvmrc', 'yarn.lock') }}
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Cypress seems to not be compatible with this approach. See error:
```console
success Already up-to-date.
Done in 0.56s.
/opt/hostedtoolcache/node/16.19.0/x64/bin/npx cypress cache list
No cached binary versions were found.
/opt/hostedtoolcache/node/16.19.0/x64/bin/npx cypress verify
The cypress npm package is installed, but the Cypress binary is missing.

We expected the binary to be installed here: /home/runner/.cache/Cypress/12.14.0/Cypress/Cypress

Reasons it may be missing:

- You're caching 'node_modules' but are not caching this path: /home/runner/.cache/Cypress
- You ran 'npm install' at an earlier build step but did not persist: /home/runner/.cache/Cypress

Properly caching the binary will fix this error and avoid downloading and unzipping Cypress.

Alternatively, you can run 'cypress install' to download the binary again.

https://on.cypress.io/not-installed-ci-error
```

Reverting the change on UI tests until we find a better approach