### PR TITLE
ci: move lint in code-quality step

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,6 +25,8 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
+      - name: Lint
+        run: yarn lint
       - name: Check TypeScript types
         run: yarn typecheck
   tests:
@@ -44,8 +46,6 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Copy .env.example
         run: cp .env.example .env
-      - name: Lint
-        run: yarn lint
       - name: Build
         run: yarn build
         # run 3 copies of the current job in parallel


### PR DESCRIPTION
As we have `code-quality` job now there's no need to just in the cypress splitted job anymore