### PR TITLE
fix(dcr): truncate show creds

### DIFF
--- a/src/components/CopyButton.vue
+++ b/src/components/CopyButton.vue
@@ -14,7 +14,7 @@
           appearance="secondary"
           @click="copyTokenToClipboard(copyToClipboard)"
         >
-          <span>{{ label }} {{ textToCopy }}</span>
+          <span class="truncate">{{ label }} {{ textToCopy }}</span>
           <KIcon
             :title="helpText.copyToClipboard"
             icon="copy"


### PR DESCRIPTION
Adds truncate to copy buttons so creds don't overflow when creating dcr application.


![Screenshot 2023-06-14 at 1 16 31 PM](https://github.com/Kong/konnect-portal/assets/15886900/9655c5d0-5f8b-4c6b-96ec-d9e396367d02)
