### PR TITLE
ci: proper permissions

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -13,6 +13,10 @@ on:
 
 jobs:
   deploy:
+    # This permission is required on the first run of running the action on a branch
+    # because the branch doesn't exist the workflow needs permission to create it
+    permissions: 
+      contents: write
     if: github.repository == 'kong/konnect-portal'
     name: deploy build to github-pages
     runs-on: ubuntu-latest


### PR DESCRIPTION
The workflow was missing the required permission for the first run when the github pages branch doesn't exist yet.