### PR TITLE
ci: ignore patch releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,6 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: build(deps)
+    ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
As there's plenty of patch releases, disabling update for those to not get a noisy ci