### PR TITLE
feat: .editorconfig integration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Adding the commonly used [editorconfig](https://editorconfig.org/) to setup the common IDE configurations for the project.