### PR TITLE
feat(documents): accept vendored content type

### DIFF
--- a/src/views/ApiDocumentationPage.vue
+++ b/src/views/ApiDocumentationPage.vue
@@ -157,7 +157,7 @@ export default defineComponent({
         documentId: slug
       }, {
         headers: {
-          accept: 'application/konnect.document-nodes+json'
+          accept: 'application/vnd.konnect.document-nodes+json'
         }
       })
         .then((res) => {


### PR DESCRIPTION
This PR updates the accept header to use vendored content type for fetching Documents