### PR TITLE
fix(LD): use featureset for ld

### DIFF
--- a/src/composables/useLaunchDarkly.ts
+++ b/src/composables/useLaunchDarkly.ts
@@ -26,7 +26,7 @@ let ldClient: LDClient | undefined
 
 export default function useLaunchDarkly () {
   const appStore = useAppStore()
-  const { featuresetId, portalId, orgId } = storeToRefs(appStore)
+  const { featuresetId, portalId, orgId, featureSet } = storeToRefs(appStore)
 
   const initialize = async () => {
     if (!enableLD) {
@@ -58,7 +58,8 @@ export default function useLaunchDarkly () {
         anonymous: false,
         custom: {
           portalId: portalId.value,
-          orgId: orgId.value
+          orgId: orgId.value,
+          featureSet: featureSet.value
         }
       }
     } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,7 @@ async function init () {
       portal_id: portalId,
       org_id: orgId,
       featureset_id: featuresetId,
+      feature_set: featureSet,
       oidc_auth_enabled: oidcAuthEnabled,
       is_public: isPublic,
       basic_auth_enabled: basicAuthEnabled,
@@ -69,7 +70,7 @@ async function init () {
 
     const isDcr = Array.isArray(dcrProviderIds) && dcrProviderIds.length > 0
 
-    setPortalData({ portalId, orgId, authClientConfig, featuresetId, isPublic, isDcr, isRbacEnabled })
+    setPortalData({ portalId, orgId, authClientConfig, featuresetId, featureSet, isPublic, isDcr, isRbacEnabled })
     setSession(session)
 
     // Fetch session data from localStorage

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -10,6 +10,7 @@ interface PortalData {
     oidcAuthEnabled: boolean;
   };
   featuresetId: string;
+  featureSet: string;
   isPublic: boolean;
   isDcr: boolean;
   isRbacEnabled: boolean;
@@ -25,6 +26,7 @@ export const useAppStore = defineStore('app', () => {
   const orgId = ref<string>(null)
   const developerSession = ref<SessionCookie>(null)
   const featuresetId = ref<string>(null)
+  const featureSet = ref<string>('')
   const authClientConfig = ref<{
     basicAuthEnabled: boolean;
     oidcAuthEnabled: boolean;
@@ -33,7 +35,7 @@ export const useAppStore = defineStore('app', () => {
     return await developerSession.value.destroy(fullPath)
   }
 
-  const setPortalData = (data: PortalData) => {
+  const setPortalData = (data: Partial<PortalData>) => {
     if (data.portalId) {
       portalId.value = data.portalId
     }
@@ -48,6 +50,10 @@ export const useAppStore = defineStore('app', () => {
 
     if (data.featuresetId) {
       featuresetId.value = data.featuresetId
+    }
+
+    if (data.featureSet) {
+      featureSet.value = data.featureSet
     }
 
     if (data.isRbacEnabled) {
@@ -77,6 +83,7 @@ export const useAppStore = defineStore('app', () => {
     orgId,
     developerSession,
     featuresetId,
+    featureSet,
     authClientConfig,
 
     logout,


### PR DESCRIPTION
This PR adds the ability to load the featureSet string from the portal context and load it for Launch Darkly (which is an optional dependency) 