### PR TITLE
fix: adjust error handling for auth elements for v2 api (TDX-3212)

### DIFF
--- a/cypress/e2e/specs/login.spec.ts
+++ b/cypress/e2e/specs/login.spec.ts
@@ -136,14 +136,9 @@ describe('Login Page', () => {
     cy.intercept('POST', '**/developer/authenticate', {
       statusCode: 401,
       body: {
-        errors: [
-          {
-            status: '401',
-            code: '1007',
-            title: 'Account is disabled',
-            detail: 'user account is disabled (#1007)'
-          }
-        ]
+        status: 401,
+        title: "Developer is disabled",
+        detail: "Your account is disabled."
       },
       delay: 300
     }).as('userAuthenticate')
@@ -156,7 +151,7 @@ describe('Login Page', () => {
     cy.wait('@userAuthenticate').then(() => {
       cy.url().should('include', '/login')
       cy.get('[data-testid="kong-auth-error-message"]')
-        .should('contain', 'Your account is pending approval for access')
+        .should('contain', 'Developer is disabled: Your account is disabled.')
     })
   })
 
@@ -200,13 +195,10 @@ describe('Login Page', () => {
     cy.intercept('POST', '**/developer/verify-email', {
       statusCode: 500,
       body: {
-        errors: [
-          {
-            status: '500',
-            title: 'Internal Server Error',
-            detail: 'invalid status update request'
-          }
-        ]
+        "status": 500,
+        "title": "Internal",
+        "instance": "konnect:trace:1158228726469534496",
+        "detail": "An internal failure occurred"
       },
       delay: 300
     }).as('verifyEmailToken')
@@ -216,7 +208,7 @@ describe('Login Page', () => {
       // returns to the login page
       cy.location('pathname').should('equal', '/login')
       cy.get('[data-testid="kong-auth-error-message"]')
-        .should('contain', 'Invalid status update request')
+        .should('contain', 'An internal failure occurred')
 
       cy.get('input[id=email]').should('exist')
     })

--- a/cypress/e2e/specs/login.spec.ts
+++ b/cypress/e2e/specs/login.spec.ts
@@ -151,7 +151,7 @@ describe('Login Page', () => {
     cy.wait('@userAuthenticate').then(() => {
       cy.url().should('include', '/login')
       cy.get('[data-testid="kong-auth-error-message"]')
-        .should('contain', 'Developer is disabled: Your account is disabled.')
+        .should('contain', 'Your account is pending approval for access')
     })
   })
 

--- a/cypress/e2e/specs/reset_password.spec.ts
+++ b/cypress/e2e/specs/reset_password.spec.ts
@@ -41,20 +41,14 @@ describe('Reset Password Page', () => {
   })
   it('Errors out if reset token is invalid', () => {
     cy.intercept('POST', '**/developer/reset-password', {
-      statusCode: 400,
+      statusCode: 500,
       body:
-        {
-          errors: [
-            {
-              status: '400',
-              title: 'Invalid Token',
-              detail: 'The password reset token is invalid',
-              source: {
-                pointer: '/token'
-              }
-            }
-          ]
-        },
+      {
+        "status": 500,
+        "title": "Internal",
+        "instance": "konnect:trace:1115722991246784904",
+        "detail": "An internal failure occurred"
+      },
       delay: 300
     }).as('resetPassword')
 
@@ -80,7 +74,7 @@ describe('Reset Password Page', () => {
 
         cy.wait('@resetPassword').then(() => {
           // Stays on the page as token is invalid
-          cy.get('[data-testid="kong-auth-error-message"]').should('contain', 'The password reset token is invalid')
+          cy.get('[data-testid="kong-auth-error-message"]').should('contain', 'An internal failure occurred')
           cy.location('pathname').should('equal', '/reset-password')
         })
       })

--- a/src/helpers/handleKongAuthElementsError.ts
+++ b/src/helpers/handleKongAuthElementsError.ts
@@ -50,18 +50,9 @@ function handleKongAuthElementsError ({ error }) {
       return validationErrors.join(', ')
     }
 
-    const errors = error?.response?.data?.errors || []
-    if (errors.length === 1) {
-      const innerError = errors[0]
-
-      switch (innerError.code) {
-        case '1007':
-          return 'Your account is pending approval for access'
-        default:
-          return null
-      }
-    } else {
-      return null
+    const errorMsg = error?.response?.data || {}
+    if (errorMsg && errorMsg.title.includes('disabled')) {
+      return `${errorMsg.title}: ${errorMsg.detail}`
     }
   }
 }

--- a/src/helpers/handleKongAuthElementsError.ts
+++ b/src/helpers/handleKongAuthElementsError.ts
@@ -52,7 +52,7 @@ function handleKongAuthElementsError ({ error }) {
 
     const errorMsg = error?.response?.data || {}
     if (errorMsg && errorMsg.title.includes('disabled')) {
-      return `${errorMsg.title}: ${errorMsg.detail}`
+      return 'Your account is pending approval for access'
     }
   }
 }


### PR DESCRIPTION
Adjust a minor piece of logic - it doesn't use code anymore, so we will just update the message based off of the returned error. 
<img width="610" alt="Screenshot 2023-06-27 at 11 49 33 AM" src="https://github.com/Kong/konnect-portal/assets/40131297/aa18b8d4-6ffa-4f86-a33b-f61ce63da8bc">
<img width="550" alt="Screenshot 2023-06-27 at 11 49 27 AM" src="https://github.com/Kong/konnect-portal/assets/40131297/f409fd0e-78f1-4503-8c01-7bc67ad363b6">
<img width="596" alt="Screenshot 2023-06-27 at 11 49 21 AM" src="https://github.com/Kong/konnect-portal/assets/40131297/60faacda-eb6e-40b4-9495-9e945f091e29">
