### PR TITLE
chore(deps): bump SDK version to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@kong-ui-public/spec-renderer": "0.9.28",
     "@kong/kong-auth-elements": "2.1.0",
     "@kong/kongponents": "8.82.2",
-    "@kong/sdk-portal-js": "0.0.1-beta.24",
+    "@kong/sdk-portal-js": "1.0.0",
     "@xstate/vue": "2.0.0",
     "axios": "0.27.2",
     "date-fns": "2.30.0",

--- a/src/views/Applications/ApplicationForm.vue
+++ b/src/views/Applications/ApplicationForm.vue
@@ -335,7 +335,7 @@ export default defineComponent({
       portalApiV2.value.service.applicationsApi
         .updateApplication({
           applicationId: id.value,
-          updateApplicationPayload: cleanupEmptyFields(formData.value)
+          updateApplicationPayload: cleanupEmptyFields(formData.value) as { name: string, [x: string]: any }
         })
         .then((res) => handleSuccess(res.data.id, 'updated'))
         .catch((error) => handleError(error))

--- a/src/views/ProductShell.vue
+++ b/src/views/ProductShell.vue
@@ -104,7 +104,7 @@ async function fetchDocumentTree () {
   try {
     const requestOptions = {
       productId: id,
-      accept: DocumentContentTypeEnum.KonnectDocumentTreejson
+      accept: DocumentContentTypeEnum.VndKonnectDocumentTreejson
     }
     // @ts-ignore
     // overriding the axios response because we're specifying what we're accepting above

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,10 +894,10 @@
     v-calendar "^3.0.0-alpha.8"
     vue-draggable-next "^2.1.1"
 
-"@kong/sdk-portal-js@0.0.1-beta.24":
-  version "0.0.1-beta.24"
-  resolved "https://registry.yarnpkg.com/@kong/sdk-portal-js/-/sdk-portal-js-0.0.1-beta.24.tgz#ca8659d4f0d513796fc1f11a305247edc3e47cc2"
-  integrity sha512-qjFeTy6dNMZNigifPf6SmmhfcwNv2I69WK1GN/TdsMuGMqZEfM5P/og4Z4Y82dksYGxaNXjjRjAhzIxfe7fyBA==
+"@kong/sdk-portal-js@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@kong/sdk-portal-js/-/sdk-portal-js-1.0.0.tgz#3472a6b27af41345a4359fe712b051d13092c2c9"
+  integrity sha512-ojXeFb94Lqxl91nJAVjZDHPIPmDwTou3oLJTqtsbtGzYKbfqdUXQllnQHe8s0/i6Io7IoRRoLmgHWHmpuLSJDw==
   dependencies:
     axios "0.27.2"
 


### PR DESCRIPTION
This bumps the Konnect Portal API v2 SDK version to 1.0.0 from the previous beta version.