### PR TITLE
fix(appreg): add optional chaining to product.name

### DIFF
--- a/src/components/ViewSpecRegistrationModal.vue
+++ b/src/components/ViewSpecRegistrationModal.vue
@@ -195,7 +195,7 @@ export default defineComponent({
 
       return {
         default: {
-          title: defaultModal.title(props.product.name, props.version?.name),
+          title: defaultModal.title(props.product?.name, props.version?.name),
           buttonText: defaultModal.buttonText
         },
         success: {


### PR DESCRIPTION
This PR adds optional chaining to `product.name` in the registration modal component