### PR TITLE
fix(products-list): fix structure for table header

### DIFF
--- a/src/views/Applications/ProductList.vue
+++ b/src/views/Applications/ProductList.vue
@@ -98,7 +98,7 @@ export default defineComponent({
       { label: nameLabel, key: 'name' },
       { label: helpText.labels.version, key: 'version' },
       { label: helpText.labels.status, key: 'status' },
-      { key: helpText.labels.actions, hideLabel: true }
+      { label: helpText.labels.actions, key: 'actions', hideLabel: true }
     ]
 
     const { portalApiV2 } = usePortalApi()


### PR DESCRIPTION
The keys were invalid so this column was not rendering before - this is for the `unregister` button for an application's registered products.