### PR TITLE
perf(vite): reduce bundle size via lazy-loaded routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ VITE_LOCALE='en'
 
 # Sets whether LaunchDarkly is enabled within the portal, defaults to false if unset
 VITE_ENABLE_LAUNCH_DARKLY=true
+
+# sets whether to create a visualization of the current project's dependency graph, defaults to false if unset
+BUILD_VISUALIZER=false

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "serve": "vite preview",
     "build": "vite build --mode production",
+    "build:analyze": "BUILD_VISUALIZER=true vite build --mode production",
     "lint": "eslint --ext .js,.ts,.vue --ignore-path .gitignore src",
     "lint:fix": "yarn lint --fix",
     "commit": "cz",
@@ -66,11 +67,12 @@
     "express": "4.18.2",
     "lefthook": "1.4.1",
     "openapi-types": "12.1.3",
+    "rollup-plugin-visualizer": "5.9.2",
     "sass": "1.63.4",
     "tailwindcss": "3.3.2",
     "typescript": "4.9.5",
-    "vite-svg-loader": "4.0.0",
     "vite": "4.4",
+    "vite-svg-loader": "4.0.0",
     "vue-tsc": "1.6.5"
   },
   "config": {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,13 +3,6 @@ import { storeToRefs } from 'pinia'
 
 import { session } from '@/services'
 import { useAppStore, useI18nStore } from '@/stores'
-import Shell from '../views/Shell.vue'
-import ProductCatalogWrapper from '../views/ProductCatalogWrapper.vue'
-import ProductShell from '../views/ProductShell.vue'
-import Registration from '../views/Registration.vue'
-import Login from '../views/Login.vue'
-import ForgotPassword from '../views/ForgotPassword.vue'
-import ResetPassword from '../views/ResetPassword.vue'
 
 import {
   canUserAccess,
@@ -23,6 +16,14 @@ import {
 } from '@/router/route-utils'
 import useLDFeatureFlag from '@/hooks/useLDFeatureFlag'
 import { FeatureFlags } from '@/constants/feature-flags'
+
+const ProductCatalogWrapper = () => import('../views/ProductCatalogWrapper.vue')
+const ProductShell = () => import('../views/ProductShell.vue')
+const Shell = () => import('../views/Shell.vue')
+const Registration = () => import('../views/Registration.vue')
+const ForgotPassword = () => import('../views/ForgotPassword.vue')
+const ResetPassword = () => import('../views/ResetPassword.vue')
+const Login = () => import('../views/Login.vue')
 
 export const portalRouter = () => {
   const appStore = useAppStore()

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,7 @@ import dns from 'dns'
 import vue from '@vitejs/plugin-vue'
 import svgLoader from 'vite-svg-loader'
 import vueJsx from '@vitejs/plugin-vue-jsx'
+import { visualizer } from 'rollup-plugin-visualizer'
 
 const path = require('path')
 
@@ -28,6 +29,14 @@ function setHostHeader (proxy) {
 export default ({ command, mode }) => {
   process.env = { ...process.env, ...loadEnv(mode, process.cwd()) }
 
+  // Include the rollup-plugin-visualizer if the BUILD_VISUALIZER env var is set to "true"
+  const buildVisualizerPlugin = process.env.BUILD_VISUALIZER === 'true' && visualizer({
+    filename: path.resolve(__dirname, 'bundle-analyzer/stats-treemap.html'),
+    template: 'treemap', // sunburst|treemap|network
+    sourcemap: true,
+    gzipSize: true
+  })
+
   // Sets VITE_INDEX_API_URL which is templated in index.html
   process.env.VITE_INDEX_API_URL = command === 'serve' ? '/' : process.env.VITE_PORTAL_API_URL
 
@@ -48,6 +57,22 @@ export default ({ command, mode }) => {
   dns.setDefaultResultOrder('verbatim')
 
   return defineConfig({
+    logLevel: 'info',
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            vue: ['vue', 'vue-router'],
+            kongponents: ['@kong/kongponents'],
+            kongAuthelements: ['@kong/kong-auth-elements'],
+            specRenderer: ['@kong-ui-public/spec-renderer']
+          }
+        },
+        plugins: [
+          buildVisualizerPlugin
+        ]
+      }
+    },
     plugins: [
       vue(
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3058,6 +3058,11 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
 define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.0.tgz#52988570670c9eacedd8064f4a990f2405849bd5"
@@ -4943,7 +4948,7 @@ is-decimal@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
   integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
 
-is-docker@^2.0.0:
+is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
@@ -5143,7 +5148,7 @@ is-windows@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
-is-wsl@^2.1.1:
+is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
@@ -6021,6 +6026,15 @@ open@^7.4.2:
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
+
+open@^8.4.0:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
+  integrity sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
 
 openapi-types@12.1.3:
   version "12.1.3"
@@ -6943,6 +6957,16 @@ rollup-plugin-babel@^4.4.0:
     "@babel/helper-module-imports" "^7.0.0"
     rollup-pluginutils "^2.8.1"
 
+rollup-plugin-visualizer@5.9.2:
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.9.2.tgz#f1aa2d9b1be8ebd6869223c742324897464d8891"
+  integrity sha512-waHktD5mlWrYFrhOLbti4YgQCn1uR24nYsNuXxg7LkPH8KdTXVWR9DNY1WU0QqokyMixVXJS4J04HNrVTMP01A==
+  dependencies:
+    open "^8.4.0"
+    picomatch "^2.3.1"
+    source-map "^0.7.4"
+    yargs "^17.5.1"
+
 rollup-pluginutils@^2.8.1:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
@@ -7233,6 +7257,11 @@ source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
+  integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
 
 sourcemap-codec@^1.4.8:
   version "1.4.8"
@@ -8411,7 +8440,7 @@ yargs-parser@^21.1.1:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs@^17.0.0, yargs@^17.7.2:
+yargs@^17.0.0, yargs@^17.5.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
## Why

We want to reduce the bundle size that's sent over the wire to improve the performance of the application.

## How

One of the lowest hanging fruit was bundle separation and dynamic importing of components for non-hot-path routes.

The other way to minify was by splitting out some of the commonly used components (i.e. `kongponents` or `kong-auth-elements` into their own bundles.

This got us from [~4100kb](https://github.com/Kong/konnect-portal/actions/runs/5512224881/jobs/10048777150#step:8:370) to [~2700](https://github.com/Kong/konnect-portal/actions/runs/5533435976/jobs/10096957616#step:6:392)

## What did we not do?

1. We didn't work to split up the spec renderer (currently the largest bundle). This will require some rework in the swagger-ui-kong-theme as well as in public-ui-components. This is important, and will be prioritized down the line, but wanted to call it out.
2. We didn't set up performance tests to log page load times. This might be done with cypress or some other tool, but was out of scope.