### PR TITLE
chore(vite): ignore css warnings triggered by dependencies

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   plugins: {
     tailwindcss: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+/** @type {import('tailwindcss').Config} */
+
 module.exports = {
   future: {
     purgeLayersByDefault: true


### PR DESCRIPTION
During the build, Vite was logging CSS warnings due to a dependency (`kong-auth-elements` via `kongponents`); however, this has no impact on the actual application.

This PR silences the specific warning by implementing a custom logger in the `vite.config.ts` that can be extended as needed.

### Before

![image](https://github.com/Kong/konnect-portal/assets/2229946/a843150b-f250-4b95-b9a7-b3a2a1f38200)

### After

![image](https://github.com/Kong/konnect-portal/assets/2229946/e07b12ea-7c41-4860-9943-7a25f330e7c3)
