### PR TITLE
fix(auth): set the base url on axios client for requests that use raw paths

### DIFF
--- a/src/services/AuthApiService.ts
+++ b/src/services/AuthApiService.ts
@@ -29,6 +29,7 @@ export default class KongAuthApi {
     this.authErrorCallback = () => false
 
     this.client = axios.create({
+      baseURL: baseUrl,
       withCredentials: true,
       headers: {
         accept: 'application/json'


### PR DESCRIPTION
Requests that use the `client` directly and specify a path were using the window location as the base url instead of the api url configured in the env. This caused the GET permissions request to fail if using a proxy in a deployed environment (like with Netlify).