### PR TITLE
chore: update tailwind.config as purge is deprecated

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,6 @@ module.exports = {
     './src/**/*.js',
     './src/**/*.vue'
   ],
-  sd: {},
   theme: {
     extend: {
       screens: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,13 +4,12 @@ module.exports = {
   future: {
     purgeLayersByDefault: true
   },
-  purge: {
-    layers: ['utilities'],
-    content: [
-      './src/**/*.js',
-      './src/**/*.vue'
-    ]
-  },
+  layers: ['utilities'],
+  content: [
+    './src/**/*.js',
+    './src/**/*.vue'
+  ],
+  sd: {},
   theme: {
     extend: {
       screens: {
@@ -21,6 +20,5 @@ module.exports = {
       }
     }
   },
-  variants: {},
   plugins: []
 }


### PR DESCRIPTION
The `tailwind.config` has a purge property that is deprecated, so the config has been refactored. 