### PR TITLE
test(*): generate uuids with crypto.randomUUID

### DIFF
--- a/cypress/e2e/fixtures/consts.ts
+++ b/cypress/e2e/fixtures/consts.ts
@@ -1,5 +1,4 @@
 import { GetApplicationResponse, GetRegistrationResponse, PortalContext, Product, ProductVersion } from '@kong/sdk-portal-js'
-import { v4 as uuidv4 } from 'uuid'
 
 const versions: ProductVersion[] = [
   {
@@ -15,7 +14,7 @@ const versions: ProductVersion[] = [
 const product: Product = {
   created_at: '2022-03-23T14:52:41.893Z',
   updated_at: '2022-03-23T14:52:41.893Z',
-  id: 'a5afb115-025e-4da1-a013-bf05b326e0a51',
+  id: '29985c03-a866-46f2-8152-29406243b90f',
   name: 'barAPI',
   description: null,
   document_count: 0,
@@ -36,14 +35,14 @@ const apps: GetApplicationResponse[] = [
     name: 'My Cool App',
     description: 'My Cool App has a cool description',
     reference_id: '1',
-    id: uuidv4(),
+    id: crypto.randomUUID(),
     created_at: '2022-03-25T13:15:02.104Z',
     updated_at: '2022-03-25T13:15:02.104Z'
   },
   {
     name: 'My Other App',
     reference_id: '2',
-    id: uuidv4(),
+    id: crypto.randomUUID(),
     created_at: '2022-03-25T13:15:02.104Z',
     updated_at: '2022-03-25T13:15:02.104Z',
     description: 'My Other App has a cool description'
@@ -52,7 +51,7 @@ const apps: GetApplicationResponse[] = [
     name: 'My Other Other App',
     description: 'My Other Other App has a cool description',
     reference_id: '3',
-    id: uuidv4(),
+    id: crypto.randomUUID(),
     created_at: '2022-03-25T13:15:02.104Z',
     updated_at: '2022-03-25T13:15:02.104Z'
   },
@@ -61,7 +60,7 @@ const apps: GetApplicationResponse[] = [
     description: 'My DCR App has a cool description',
     reference_id: '4',
     redirect_uri: 'http://google.com',
-    id: uuidv4(),
+    id: crypto.randomUUID(),
     created_at: '2022-03-25T13:15:02.104Z',
     updated_at: '2022-03-25T13:15:02.104Z'
   }

--- a/cypress/e2e/specs/catalog.spec.ts
+++ b/cypress/e2e/specs/catalog.spec.ts
@@ -1,23 +1,21 @@
 import { SearchResults, SearchResultsDataInner } from '@kong/sdk-portal-js'
-import { v4 as uuidv4 } from 'uuid'
 import { generateProducts } from '../support/utils/generateProducts'
-import { FeatureFlags } from '@/constants/feature-flags'
 
 const mockProductSearchQuery = (searchQuery: string) => {
-  const searchResults: SearchResultsDataInner[] = [
-    ['barAPI', ['v1-beta'], uuidv4()],
-    ['fooApi', ['v1'], uuidv4()],
-    ['sampleapi', ['v1'], uuidv4()],
-    ['testapi', ['v1'], uuidv4()],
-    ['xapi', ['v1'], uuidv4()]
-  ]
+  const searchResults: SearchResultsDataInner[] = ([
+    ['barAPI', ['v1-beta']],
+    ['fooApi', ['v1']],
+    ['sampleapi', ['v1']],
+    ['testapi', ['v1']],
+    ['xapi', ['v1']]
+  ] as [string, string[]][])
     .filter((data) =>
       searchQuery !== '' ? JSON.stringify(data).includes(searchQuery) : true
     )
-    .map(([name, versions, id]) => ({
+    .map(([name, versions]) => ({
       index: 'product-catalog',
       source: {
-        id,
+        id: crypto.randomUUID(),
         description: '',
         document_count: 0,
         created_at: '',
@@ -25,8 +23,8 @@ const mockProductSearchQuery = (searchQuery: string) => {
         name,
         version_count: versions.length,
         latest_version: {
-          name: versions[0].name,
-          id: versions[0].id
+          name: versions[0],
+          id: crypto.randomUUID()
         }
       }
     }))
@@ -70,7 +68,6 @@ const mockProductSearchResults = (searchResults:SearchResultsDataInner[], pageNu
 }
 
 describe('Catalog', () => {
-
   beforeEach(() => {
     cy.mockStylesheetFont()
     cy.mockAppearance()
@@ -87,8 +84,8 @@ describe('Catalog', () => {
 
     it('loads one product with details', () => {
       cy.get('.catalog-item').should('have.length', 1)
-      cy.get('.catalog-item').should('contain', 'barAPI')
-      cy.get('.catalog-item').should('contain', 'v2')
+      cy.get('.catalog-item').should('contain', 'barAPI0')
+      cy.get('.catalog-item').should('contain', 'v0')
       cy.get('.catalog-item').should('contain', 'great description')
     })
 

--- a/cypress/e2e/specs/portal_auth.spec.ts
+++ b/cypress/e2e/specs/portal_auth.spec.ts
@@ -1,8 +1,6 @@
-import { v4 as uuidv4 } from 'uuid'
-
-const productId = 'a5afb115-025e-4da1-a013-bf05b326e0a51'
-const productVersionId = '1afac832-5b2a-474c-a56d-c241364f41cf'
-const applicationId = uuidv4()
+const productId = crypto.randomUUID()
+const productVersionId = crypto.randomUUID()
+const applicationId = crypto.randomUUID()
 
 const matrix = {
   isNotPublic: {

--- a/cypress/e2e/support/mock-commands.ts
+++ b/cypress/e2e/support/mock-commands.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from 'uuid'
 import petstoreJson from '../fixtures/oas_specs/petstoreJson.json'
 import petstoreJson30 from '../fixtures/oas_specs/petstoreJson3.0.json'
 import { generateProducts } from './utils/generateProducts'
@@ -138,7 +137,7 @@ Cypress.Commands.add('mockDcrPortal', () => {
 
   const portalContextResponse: PortalContext = {
     ...defaultContext,
-    dcr_provider_ids: [uuidv4()]
+    dcr_provider_ids: [crypto.randomUUID()]
   }
 
   return cy.intercept('GET', '**/api/v2/portal', {
@@ -371,8 +370,8 @@ Cypress.Commands.add('mockProductsCatalog', (count = 1, overrides = [], pageNum 
 })
 
 Cypress.Commands.add('mockGetProductDocumentBySlug', (productId, slug, options = {}) => {
-  const docId = uuidv4()
-  const revId = uuidv4()
+  const docId = crypto.randomUUID()
+  const revId = crypto.randomUUID()
   const time = new Date().toISOString()
 
   const resp = {
@@ -405,7 +404,7 @@ Cypress.Commands.add('mockGetProductDocumentBySlug', (productId, slug, options =
 })
 
 Cypress.Commands.add('mockGetProductDocuments', (productId) => {
-  const docId = uuidv4()
+  const docId = crypto.randomUUID()
 
   const resp: ListDocumentsTree = {
     data: generateDocuments(docId),

--- a/cypress/e2e/support/utils/generateDocuments.ts
+++ b/cypress/e2e/support/utils/generateDocuments.ts
@@ -1,10 +1,9 @@
 import { DocumentTree } from '@kong/sdk-portal-js'
-import { v4 as uuidv4 } from 'uuid'
 
 export function generateDocuments (docId: any): DocumentTree[] {
   return [
     {
-      id: uuidv4(),
+      id: crypto.randomUUID(),
       parent_document_id: null,
       slug: 'mock-document-1',
       title: 'Mock Document #1',
@@ -12,7 +11,7 @@ export function generateDocuments (docId: any): DocumentTree[] {
       children: []
     },
     {
-      id: uuidv4(),
+      id: crypto.randomUUID(),
       parent_document_id: null,
       slug: 'mock-document-2',
       title: 'Mock Document #3',
@@ -27,7 +26,7 @@ export function generateDocuments (docId: any): DocumentTree[] {
       meta: {},
       children: [
         {
-          id: uuidv4(),
+          id: crypto.randomUUID(),
           parent_document_id: docId,
           slug: 'child-document-1',
           title: 'Child Document #1',
@@ -35,7 +34,7 @@ export function generateDocuments (docId: any): DocumentTree[] {
           children: []
         },
         {
-          id: uuidv4(),
+          id: crypto.randomUUID(),
           parent_document_id: docId,
           slug: 'child-document-2',
           title: 'Child Document #2',

--- a/cypress/e2e/support/utils/generateProducts.ts
+++ b/cypress/e2e/support/utils/generateProducts.ts
@@ -7,7 +7,7 @@ export const generateProducts = (count: number, options: Partial<ProductCatalogI
     productsList.push({
       index: 'product-catalog',
       source: {
-        id: 'a5afb115-025e-4da1-a013-bf05b326e0a5' + i,
+        id: crypto.randomUUID(),
         created_at: '2020-08-25T16:14:52.450Z',
         updated_at: '2020-08-25T16:14:52.450Z',
         name: 'barAPI' + i,
@@ -25,7 +25,7 @@ export const generateProducts = (count: number, options: Partial<ProductCatalogI
 
 function generateLatestVersion (i: number): ProductCatalogIndexSourceLatestVersion {
   return {
-    id: 'a41041e4-d324-43c8-977a-ad68f1839751' + i,
-    name: 'v2'
+    id: crypto.randomUUID(),
+    name: `v${i}`
   }
 }


### PR DESCRIPTION
- Fixes tests that could generate invalid UUIDs by appending 1 or 2 digit numbers to a fixed-length uuid prefix
- Ensures that all code uses `crypto.randomUUID()` rather than the `uuid` package since `crypto` is available in all modern browsers and the `uuid` package is not an explicit dependency of `konnect-portal` (it happens to be available as a sub-dependency)