### PR TITLE
chore(flag): remove product naming feature flag

### DIFF
--- a/cypress/e2e/specs/catalog.spec.ts
+++ b/cypress/e2e/specs/catalog.spec.ts
@@ -92,18 +92,9 @@ describe('Catalog', () => {
       cy.get('.catalog-item').should('contain', 'great description')
     })
 
-    it('TDX-3134 - catalog title should read "Service" when flag disabled', () => {
-      cy.mockLaunchDarklyFlags([{ name: FeatureFlags.ApiProductBuilder, value: false }]).then(() => {
-        cy.get('.products-label').should('contain', 'Service')
-        cy.title().should('eq', 'Service Catalog | Developer Portal')
-      })
-    })
-
-    it('TDX-3134 - catalog title should read "Product" when flag enabled', () => {
-      cy.mockLaunchDarklyFlags([{ name: FeatureFlags.ApiProductBuilder, value: true }]).then(() => {
-        cy.get('.products-label').should('contain', 'Product')
-        cy.title().should('eq', 'Product Catalog | Developer Portal')
-      })
+    it('sets the catalog title', () => {
+      cy.get('.products-label').should('contain', 'Product')
+      cy.title().should('eq', 'Product Catalog | Developer Portal')
     })
 
     it('goes to details view on header click', () => {

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -52,8 +52,6 @@ import EmptyState from '../assets/catalog-empty-state.svg'
 import CatalogCardList from './CatalogCardList.vue'
 import CatalogTableList from './CatalogTableList.vue'
 import { CatalogItemModel, useI18nStore } from '@/stores'
-import useLDFeatureFlag from '@/hooks/useLDFeatureFlag'
-import { FeatureFlags } from '@/constants/feature-flags'
 
 export default defineComponent({
   name: 'Catalog',
@@ -87,9 +85,8 @@ export default defineComponent({
   emits: ['cards-page-changed', 'active-view-changed'],
   setup () {
     const helpText = useI18nStore().state.helpText.catalog
-    const apiProductLanguageEnabled = useLDFeatureFlag(FeatureFlags.ApiProductBuilder, false)
-    const catalogTitle = apiProductLanguageEnabled ? helpText.entityTypeProduct : helpText.entityTypeService
-    const noResultsMessage = apiProductLanguageEnabled ? helpText.noResultsProduct : helpText.noResultsService
+    const catalogTitle = helpText.entityTypeProduct
+    const noResultsMessage = helpText.noResultsProduct
 
     return {
       helpText,

--- a/src/components/ViewSpecRegistrationModal.vue
+++ b/src/components/ViewSpecRegistrationModal.vue
@@ -128,8 +128,6 @@ import usePortalApi from '@/hooks/usePortalApi'
 import { useI18nStore } from '@/stores'
 import getMessageFromError from '@/helpers/getMessageFromError'
 import { fetchAll } from '@/helpers/fetchAll'
-import useLDFeatureFlag from '@/hooks/useLDFeatureFlag'
-import { FeatureFlags } from '@/constants/feature-flags'
 
 export default defineComponent({
   name: 'ViewSpecRegistrationModal',
@@ -155,7 +153,6 @@ export default defineComponent({
   emits: ['close'],
 
   setup (props, { emit }) {
-    const apiProductFlagEnabled = useLDFeatureFlag(FeatureFlags.ApiProductBuilder, false)
     const $router = useRouter()
     const $route = useRoute()
     const { notify } = useToaster()
@@ -321,7 +318,7 @@ export default defineComponent({
       }
     })
 
-    const alreadyRegisteredMessage = apiProductFlagEnabled ? helpText.applicationRegistration.registeredApplicationsProduct : helpText.applicationRegistration.registeredApplicationsService
+    const alreadyRegisteredMessage = helpText.applicationRegistration.registeredApplicationsProduct
 
     return {
       currentState,

--- a/src/components/product/Sidebar.vue
+++ b/src/components/product/Sidebar.vue
@@ -36,14 +36,11 @@ import SectionOverview from './sidebar/SectionOverview.vue'
 import SectionReference from './sidebar/SectionReference.vue'
 import { storeToRefs } from 'pinia'
 import { useI18nStore, useProductStore } from '@/stores'
-import useLDFeatureFlag from '@/hooks/useLDFeatureFlag'
-import { FeatureFlags } from '@/constants/feature-flags'
 
 const productStore = useProductStore()
 const { product, activeProductVersionId } = storeToRefs(productStore)
 const helpText = useI18nStore().state.helpText.sidebar
-const apiProductLanguageEnabled = useLDFeatureFlag(FeatureFlags.ApiProductBuilder, false)
-const noResultsMessage = apiProductLanguageEnabled ? helpText.noResultsProduct : helpText.noResultsService
+const noResultsMessage = helpText.noResultsProduct
 
 const emit = defineEmits(['operationSelected'])
 

--- a/src/constants/feature-flags.ts
+++ b/src/constants/feature-flags.ts
@@ -1,3 +1,2 @@
 export enum FeatureFlags {
-  ApiProductBuilder = 'KHCP-5754-api-product-builder'
 }

--- a/src/locales/ca_ES.ts
+++ b/src/locales/ca_ES.ts
@@ -37,7 +37,6 @@ export const ca_ES: I18nType = {
   },
   productVersion: {
     deprecatedWarningProduct: "Aquesta versió del producte ja no està vigent. Els punts d'interacció seguiran sent totalment funcionals fins que aquesta versió sigui retirada.",
-    deprecatedWarningService: "Aquesta versió del servei ja no està vigent. Els punts d'interacció seguiran sent totalment funcionals fins que aquesta versió sigui retirada.",
     unableToRetrieveDoc: 'No es pot recuperar la documentació'
   },
   userDropdown: {
@@ -124,20 +123,16 @@ export const ca_ES: I18nType = {
   },
   productList: {
     titleProducts: 'Productes',
-    titleServices: 'Serveis',
     actions: {
       unregister: 'Anul·lar el registre'
     },
     emptyState: {
       titleProducts: 'Sense productes',
-      titleServices: 'Sense serveis',
       viewCatalog1: 'Vegeu el catàleg',
-      viewCatalog2Product: 'per registrar-vos en un producte.',
-      viewCatalog2Service: 'per registrar-vos en un servei.'
+      viewCatalog2Product: 'per registrar-vos en un producte.'
     },
     labels: {
       nameProduct: 'Producte',
-      nameService: 'Servei',
       version: 'Versió',
       status: 'Estat',
       actions: 'Accions'
@@ -163,7 +158,6 @@ export const ca_ES: I18nType = {
     createApplication: 'Crear una aplicació',
     cancelButton: 'Cancel·lar',
     registeredApplicationsProduct: 'Les següents aplicacions ja estan registrades en aquest producte:',
-    registeredApplicationsService: 'Les següents aplicacions ja estan registrades en aquest servei:',
     modalApplicationRegistrationDefault: {
       title: (serviceName: string, productVersion: string) => `Registrar - se per a ${serviceName} - ${productVersion}`,
       buttonText: 'Sol·licitar accés'
@@ -194,14 +188,11 @@ export const ca_ES: I18nType = {
   },
   sidebar: {
     deprecated: ' (Desactivat)',
-    noResultsProduct: 'Sense versions de producte',
-    noResultsService: 'Sense versions de servei'
+    noResultsProduct: 'Sense versions de producte'
   },
   catalog: {
     entityTypeProduct: 'Producte',
-    entityTypeService: 'Servei',
-    noResultsProduct: 'No hi ha productes disponibles',
-    noResultsService: 'No hi ha serveis disponibles'
+    noResultsProduct: 'No hi ha productes disponibles'
   },
   catalogItem: {
     latestVersion: 'Última versió:',
@@ -231,7 +222,6 @@ export const ca_ES: I18nType = {
   },
   nav: {
     catalog: 'Catàleg',
-    breadcrumbService: 'Servei',
     breadcrumbProduct: 'Producte',
     breadcrumbDocumentation: 'Documentació',
     logoAlt: 'logotip'
@@ -272,7 +262,6 @@ export const ca_ES: I18nType = {
     forgotPasswordTitle: 'Heu oblidat la contrasenya',
     resetPasswordTitle: 'Restablir la contrasenya',
     catalogTitleProduct: 'Catàleg de productes',
-    catalogTitleService: 'Catàleg de serveis',
     specTitle: "Especificació de l'API",
     docsTitle: "Documentació de l'API",
     appsTitle: 'Les meves aplicacions',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -37,7 +37,6 @@ export const de: I18nType = {
   },
   productVersion: {
     deprecatedWarningProduct: 'Diese Produktversion ist veraltet. Die Endpunkte bleiben voll funktionsfähig, bis diese Version eingestellt wird.',
-    deprecatedWarningService: 'Dieser Service ist veraltet. Die Endpunkte bleiben voll funktionsfähig, bis diese Version eingestellt wird.',
     unableToRetrieveDoc: 'Keine Dokumentation verfügbar'
   },
   userDropdown: {
@@ -124,20 +123,16 @@ export const de: I18nType = {
   },
   productList: {
     titleProducts: 'Produkte',
-    titleServices: 'Services',
     actions: {
       unregister: 'Registrierung aufheben'
     },
     emptyState: {
       titleProducts: 'Keine Produkte',
-      titleServices: 'Keine Services',
       viewCatalog1: 'Katalog ansehen, um sich für ein',
-      viewCatalog2Product: ' Produkt zu registrieren.',
-      viewCatalog2Service: 'en Service zu registrieren.'
+      viewCatalog2Product: ' Produkt zu registrieren.'
     },
     labels: {
       nameProduct: 'Produkt',
-      nameService: 'Service',
       version: 'Version',
       status: 'Status',
       actions: 'Aktionen'
@@ -163,7 +158,6 @@ export const de: I18nType = {
     createApplication: 'Neue Applikation anlegen',
     cancelButton: 'Abbruch',
     registeredApplicationsProduct: 'Die folgenden Applikationen sind bereits für dieses Produkt registriert:',
-    registeredApplicationsService: 'Die folgenden Applikationen sind bereits für diesen Service registriert:',
     modalApplicationRegistrationDefault: {
       title: (serviceName: string, productVersion: string) => `Für ${serviceName} - ${productVersion} registrieren`,
       buttonText: 'Zugriff anfragen'
@@ -194,14 +188,11 @@ export const de: I18nType = {
   },
   sidebar: {
     deprecated: ' (Veraltet)',
-    noResultsProduct: 'Keine Produktversionen',
-    noResultsService: 'Keine Serviceversionen'
+    noResultsProduct: 'Keine Produktversionen'
   },
   catalog: {
     entityTypeProduct: 'Produkt',
-    entityTypeService: 'Service',
-    noResultsProduct: 'Keine Produkte gefunden',
-    noResultsService: 'Keine Services gefunden'
+    noResultsProduct: 'Keine Produkte gefunden'
   },
   catalogItem: {
     latestVersion: 'Aktuelle Version:',
@@ -231,7 +222,6 @@ export const de: I18nType = {
   },
   nav: {
     catalog: 'Katalog',
-    breadcrumbService: 'Service',
     breadcrumbProduct: 'Produkt',
     breadcrumbDocumentation: 'Dokumentation',
     logoAlt: 'Logo'
@@ -272,7 +262,6 @@ export const de: I18nType = {
     forgotPasswordTitle: 'Passwort vergessen',
     resetPasswordTitle: 'Passwort zurücksetzen',
     catalogTitleProduct: 'Produktkatalog',
-    catalogTitleService: 'Servicekatalog',
     specTitle: 'API Spezifikation',
     docsTitle: 'API Dokumentation',
     appsTitle: 'Meine Applikationen',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -35,7 +35,6 @@ export const en = {
   },
   productVersion: {
     deprecatedWarningProduct: 'This product version is now deprecated. The endpoints will remain fully usable until this version is sunsetted.',
-    deprecatedWarningService: 'This service version is now deprecated. The endpoints will remain fully usable until this version is sunsetted.',
     unableToRetrieveDoc: 'Unable to retrieve documentation'
   },
   userDropdown: {
@@ -122,20 +121,16 @@ export const en = {
   },
   productList: {
     titleProducts: 'Products',
-    titleServices: 'Services',
     actions: {
       unregister: 'Unregister'
     },
     emptyState: {
       titleProducts: 'No Products',
-      titleServices: 'No Services',
       viewCatalog1: 'View the catalog',
-      viewCatalog2Product: 'to register to a product.',
-      viewCatalog2Service: 'to register to a service.'
+      viewCatalog2Product: 'to register to a product.'
     },
     labels: {
       nameProduct: 'Product',
-      nameService: 'Service',
       version: 'Version',
       status: 'Status',
       actions: 'Actions'
@@ -161,7 +156,6 @@ export const en = {
     createApplication: 'Create an Application',
     cancelButton: 'Cancel',
     registeredApplicationsProduct: 'The following applications are already registered to this product:',
-    registeredApplicationsService: 'The following applications are already registered to this service:',
     modalApplicationRegistrationDefault: {
       title: (serviceName: string, productVersion: string) => `Register for ${serviceName} - ${productVersion}`,
       buttonText: 'Request Access'
@@ -192,14 +186,11 @@ export const en = {
   },
   sidebar: {
     deprecated: ' (Deprecated)',
-    noResultsProduct: 'No product versions',
-    noResultsService: 'No service versions'
+    noResultsProduct: 'No product versions'
   },
   catalog: {
     entityTypeProduct: 'Product',
-    entityTypeService: 'Service',
-    noResultsProduct: 'No Products listed',
-    noResultsService: 'No Services listed'
+    noResultsProduct: 'No Products listed'
   },
   catalogItem: {
     latestVersion: 'Latest Version:',
@@ -229,7 +220,6 @@ export const en = {
   },
   nav: {
     catalog: 'Catalog',
-    breadcrumbService: 'Service',
     breadcrumbProduct: 'Product',
     breadcrumbDocumentation: 'Documentation',
     logoAlt: 'logo'
@@ -270,7 +260,6 @@ export const en = {
     forgotPasswordTitle: 'Forgot Password',
     resetPasswordTitle: 'Reset Password',
     catalogTitleProduct: 'Product Catalog',
-    catalogTitleService: 'Service Catalog',
     specTitle: 'API Spec',
     docsTitle: 'API Docs',
     appsTitle: 'My Apps',

--- a/src/locales/es_ES.ts
+++ b/src/locales/es_ES.ts
@@ -37,7 +37,6 @@ export const es_ES: I18nType = {
   },
   productVersion: {
     deprecatedWarningProduct: 'Esta versión del producto está obsoleta. La interfaz seguirá siendo totalmente utilizable hasta que esta versión se elimine.',
-    deprecatedWarningService: 'Esta versión del servicio está obsoleta. La interfaz seguirá siendo totalmente utilizable hasta que esta versión se elimine.',
     unableToRetrieveDoc: 'No se puede recuperar la documentación'
   },
   userDropdown: {
@@ -124,20 +123,16 @@ export const es_ES: I18nType = {
   },
   productList: {
     titleProducts: 'Productos',
-    titleServices: 'Servicios',
     actions: {
       unregister: 'Cancelar registro'
     },
     emptyState: {
       titleProducts: 'Sin productos',
-      titleServices: 'Sin servicios',
       viewCatalog1: 'Ver el catálogo',
-      viewCatalog2Product: 'para registrarte a un producto.',
-      viewCatalog2Service: 'para registrarte a un servicio.'
+      viewCatalog2Product: 'para registrarte a un producto.'
     },
     labels: {
       nameProduct: 'Producto',
-      nameService: 'Servicio',
       version: 'Versión',
       status: 'Estado',
       actions: 'Acciones'
@@ -163,7 +158,6 @@ export const es_ES: I18nType = {
     createApplication: 'Crear aplicación',
     cancelButton: 'Cancelar',
     registeredApplicationsProduct: 'Las siguientes aplicaciones ya están registradas para este producto:',
-    registeredApplicationsService: 'Las siguientes aplicaciones ya están registradas para este servicio:',
     modalApplicationRegistrationDefault: {
       title: (serviceName: string, productVersion: string) => `Registro para ${serviceName} - ${productVersion}`,
       buttonText: 'Soliciar acceso'
@@ -194,14 +188,11 @@ export const es_ES: I18nType = {
   },
   sidebar: {
     deprecated: ' (Obsoleto)',
-    noResultsProduct: 'No hay versiones del producto',
-    noResultsService: 'No hay versiones del servicio'
+    noResultsProduct: 'No hay versiones del producto'
   },
   catalog: {
     entityTypeProduct: 'Producto',
-    entityTypeService: 'Servicio',
-    noResultsProduct: 'No hay productos disponibles',
-    noResultsService: 'No hay servicios disponibles'
+    noResultsProduct: 'No hay productos disponibles'
   },
   catalogItem: {
     latestVersion: 'Última versión: ',
@@ -231,7 +222,6 @@ export const es_ES: I18nType = {
   },
   nav: {
     catalog: 'Catálogo',
-    breadcrumbService: 'Servicio',
     breadcrumbProduct: 'Producto',
     breadcrumbDocumentation: 'Documentación',
     logoAlt: 'logo'
@@ -272,7 +262,6 @@ export const es_ES: I18nType = {
     forgotPasswordTitle: 'Olvidé mi contraseña',
     resetPasswordTitle: 'Restablecer contraseña',
     catalogTitleProduct: 'Catálogo de productos',
-    catalogTitleService: 'Catálogo de servicios',
     specTitle: 'Especificación de la API',
     docsTitle: 'Documentación de la API',
     appsTitle: 'Mis aplicacione',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -37,7 +37,6 @@ export const fr: I18nType = {
   },
   productVersion: {
     deprecatedWarningProduct: 'Cette version du produit est maintenant obsolète. Les points d\'accès resteront entièrement utilisables jusqu\'à la fin de cette version.',
-    deprecatedWarningService: 'Cette version du service est maintenant obsolète. Les points d\'accès resteront entièrement utilisables jusqu\'à la fin de cette version.',
     unableToRetrieveDoc: 'Impossible de récupérer la documentation'
   },
   userDropdown: {
@@ -124,20 +123,16 @@ export const fr: I18nType = {
   },
   productList: {
     titleProducts: 'Produits',
-    titleServices: 'Services',
     actions: {
       unregister: 'Désenregistrer'
     },
     emptyState: {
       titleProducts: 'Aucun produit',
-      titleServices: 'Aucun service',
       viewCatalog1: 'Voir le catalogue',
-      viewCatalog2Product: 'pour vous inscrire à un produit.',
-      viewCatalog2Service: 'pour vous inscrire à un service.'
+      viewCatalog2Product: 'pour vous inscrire à un produit.'
     },
     labels: {
       nameProduct: 'Produit',
-      nameService: 'Service',
       version: 'Version',
       status: 'Statut',
       actions: 'Actions'
@@ -163,7 +158,6 @@ export const fr: I18nType = {
     createApplication: 'Créer une application',
     cancelButton: 'Annuler',
     registeredApplicationsProduct: 'Les applications suivantes sont déjà enregistrées pour ce produit :',
-    registeredApplicationsService: 'Les applications suivantes sont déjà enregistrées pour ce service :',
     modalApplicationRegistrationDefault: {
       title: (serviceName: string, productVersion: string) => `Inscription à ${serviceName} - ${productVersion}`,
       buttonText: 'Demander l\'accès'
@@ -194,14 +188,11 @@ export const fr: I18nType = {
   },
   sidebar: {
     deprecated: ' (Obsolète)',
-    noResultsProduct: 'Aucune version de produit',
-    noResultsService: 'Aucune version de service'
+    noResultsProduct: 'Aucune version de produit'
   },
   catalog: {
     entityTypeProduct: 'Produit',
-    entityTypeService: 'Service',
-    noResultsProduct: 'Aucun produit répertorié',
-    noResultsService: 'Aucun service répertorié'
+    noResultsProduct: 'Aucun produit répertorié'
   },
   catalogItem: {
     latestVersion: 'Dernière version :',
@@ -231,7 +222,6 @@ export const fr: I18nType = {
   },
   nav: {
     catalog: 'Catalogue',
-    breadcrumbService: 'Service',
     breadcrumbProduct: 'Produit',
     breadcrumbDocumentation: 'Documentation',
     logoAlt: 'logo'
@@ -272,7 +262,6 @@ export const fr: I18nType = {
     forgotPasswordTitle: 'Mot de passe oublié',
     resetPasswordTitle: 'Réinitialisation du mot de passe',
     catalogTitleProduct: 'Catalogue des produits',
-    catalogTitleService: 'Catalogue des services',
     specTitle: 'Spécification de l\'API',
     docsTitle: 'Documentation de l\'API',
     appsTitle: 'Mes applications',

--- a/src/locales/i18n-type.d.ts
+++ b/src/locales/i18n-type.d.ts
@@ -35,7 +35,6 @@ export interface I18nType {
   };
   productVersion: {
     deprecatedWarningProduct: string;
-    deprecatedWarningService: string;
     unableToRetrieveDoc: string;
   };
   userDropdown: {
@@ -122,20 +121,16 @@ export interface I18nType {
   };
   productList: {
     titleProducts: string;
-    titleServices: string;
     actions: {
       unregister: string;
     };
     emptyState: {
       titleProducts: string;
-      titleServices: string;
       viewCatalog1: string;
       viewCatalog2Product: string;
-      viewCatalog2Service: string;
     };
     labels: {
       nameProduct: string;
-      nameService: string;
       version: string;
       status: string;
       actions: string;
@@ -161,7 +156,6 @@ export interface I18nType {
     createApplication: string;
     cancelButton: string;
     registeredApplicationsProduct: string;
-    registeredApplicationsService: string;
     modalApplicationRegistrationDefault: {
       title: (serviceName: string, productVersion: string) => string;
       buttonText: string;
@@ -193,13 +187,10 @@ export interface I18nType {
   sidebar: {
     deprecated: string;
     noResultsProduct: string;
-    noResultsService: string;
   };
   catalog: {
     entityTypeProduct: string;
-    entityTypeService: string;
     noResultsProduct: string;
-    noResultsService: string;
   };
   catalogItem: {
     latestVersion: string;
@@ -229,7 +220,6 @@ export interface I18nType {
   };
   nav: {
     catalog: string;
-    breadcrumbService: string;
     breadcrumbProduct: string;
     breadcrumbDocumentation: string;
     logoAlt: string;
@@ -270,7 +260,6 @@ export interface I18nType {
     forgotPasswordTitle: string;
     resetPasswordTitle: string;
     catalogTitleProduct: string;
-    catalogTitleService: string;
     specTitle: string;
     docsTitle: string;
     appsTitle: string;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -14,8 +14,6 @@ import {
   shouldDeveloperAccessRoute,
   shouldRedirectToLogin
 } from '@/router/route-utils'
-import useLDFeatureFlag from '@/hooks/useLDFeatureFlag'
-import { FeatureFlags } from '@/constants/feature-flags'
 
 const ProductCatalogWrapper = () => import('../views/ProductCatalogWrapper.vue')
 const ProductShell = () => import('../views/ProductShell.vue')
@@ -28,7 +26,6 @@ const Login = () => import('../views/Login.vue')
 export const portalRouter = () => {
   const appStore = useAppStore()
   const { portalId, globalLoading, isPublic } = storeToRefs(appStore)
-  const apiProductLanguageEnabled = useLDFeatureFlag(FeatureFlags.ApiProductBuilder, false)
   const helpText = useI18nStore().state.helpText.router
 
   const router = createRouter({
@@ -74,7 +71,7 @@ export const portalRouter = () => {
             path: '',
             name: 'catalog',
             meta: {
-              title: apiProductLanguageEnabled ? helpText.catalogTitleProduct : helpText.catalogTitleService
+              title: helpText.catalogTitleProduct
             },
             component: ProductCatalogWrapper
           },

--- a/src/views/ApiDocumentationPage.vue
+++ b/src/views/ApiDocumentationPage.vue
@@ -57,8 +57,6 @@ import DocumentViewer, { HeadingNode, addSlug } from '@kong-ui-public/document-v
 
 import '@kong-ui-public/document-viewer/dist/style.css'
 import { DocumentBlock, ProductDocument } from '@kong/sdk-portal-js'
-import useLDFeatureFlag from '@/hooks/useLDFeatureFlag'
-import { FeatureFlags } from '@/constants/feature-flags'
 
 export default defineComponent({
   name: 'ApiDocumentationPage',
@@ -77,7 +75,6 @@ export default defineComponent({
     const helpText = useI18nStore().state.helpText
     const productStore = useProductStore()
     const { activeDocumentSlug } = storeToRefs(productStore)
-    const apiBuilderFlagEnabled = useLDFeatureFlag(FeatureFlags.ApiProductBuilder, false)
 
     const { notify } = useToaster()
     const errorCode = ref(null)
@@ -100,7 +97,7 @@ export default defineComponent({
               }
             }
           : undefined,
-        text: props.product?.name || (apiBuilderFlagEnabled ? helpText.nav.breadcrumbProduct : helpText.nav.breadcrumbService)
+        text: props.product?.name || (helpText.nav.breadcrumbProduct)
       },
       {
         key: 'documentation',

--- a/src/views/Applications/ProductList.vue
+++ b/src/views/Applications/ProductList.vue
@@ -72,8 +72,6 @@ import usePortalApi from '@/hooks/usePortalApi'
 import PageTitle from '@/components/PageTitle.vue'
 import StatusBadge from '@/components/StatusBadge.vue'
 import ActionsDropdown from '@/components/ActionsDropdown.vue'
-import useLDFeatureFlag from '@/hooks/useLDFeatureFlag'
-import { FeatureFlags } from '@/constants/feature-flags'
 
 export default defineComponent({
   name: 'ProductList',
@@ -85,13 +83,12 @@ export default defineComponent({
     }
   },
   setup (props) {
-    const apiProductLanguageEnabled = useLDFeatureFlag(FeatureFlags.ApiProductBuilder, false)
     const helpText = useI18nStore().state.helpText.productList
 
-    const nameLabel = apiProductLanguageEnabled ? helpText.labels.nameProduct : helpText.labels.nameService
-    const title = apiProductLanguageEnabled ? helpText.titleProducts : helpText.titleServices
-    const emptyStateTitle = apiProductLanguageEnabled ? helpText.emptyState.titleProducts : helpText.emptyState.titleServices
-    const viewCatalog2 = apiProductLanguageEnabled ? helpText.emptyState.viewCatalog2Product : helpText.emptyState.viewCatalog2Service
+    const nameLabel = helpText.labels.nameProduct
+    const title = helpText.titleProducts
+    const emptyStateTitle = helpText.emptyState.titleProducts
+    const viewCatalog2 = helpText.emptyState.viewCatalog2Product
 
     const { notify } = useToaster()
     const tableHeaders = [

--- a/src/views/ProductShell.vue
+++ b/src/views/ProductShell.vue
@@ -45,8 +45,6 @@ import { fetchAll } from '@/helpers/fetchAll'
 import { Operation } from '@kong-ui-public/spec-renderer'
 import { AxiosResponse } from 'axios'
 import { sortByDate } from '@/helpers/sortBy'
-import useLDFeatureFlag from '@/hooks/useLDFeatureFlag'
-import { FeatureFlags } from '@/constants/feature-flags'
 
 const { notify } = useToaster()
 const helpText = useI18nStore().state.helpText
@@ -57,8 +55,7 @@ const productError = ref(null)
 const activeProductVersionDeprecated = ref(false)
 const deselectOperation = ref<boolean>(false)
 
-const apiProductLanguageEnabled = useLDFeatureFlag(FeatureFlags.ApiProductBuilder, false)
-const deprecatedWarning = apiProductLanguageEnabled ? helpText.productVersion.deprecatedWarningProduct : helpText.productVersion.deprecatedWarningService
+const deprecatedWarning = helpText.productVersion.deprecatedWarningProduct
 
 // @ts-ignore
 const productStore = useProductStore()


### PR DESCRIPTION
API Product Builder has been released in Konnect and we no longer need the "service" naming in the UI, only "product".