### PR TITLE
chore(ci): add lint and type check as required for tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,6 +32,7 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
+    needs: code-quality
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Adds 'needs: code-quality' condition to test matrix. The 'tests' job should not be run if linting fails.