### PR TITLE
ci: check PR title instead of commits

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,19 @@
+name: Check PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - uses: aslafy-z/conventional-pr-title-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v5
       - name: Check unpinned versions
         run: ./.github/scripts/pin-version
       - name: node modules cache

--- a/README.md
+++ b/README.md
@@ -120,14 +120,13 @@ First and foremost please and comply with the standards outlined in the [CODE_OF
   ```
 
 #### _Note:_
-
- _To disable commit formatting on your fork you can either comment out the contents of the lefthook.yaml file or remove it, as well as uninstall lefthook from the package.json file._
+ _To disable linting during the `pre-push` git hook (on your fork), you can either comment out the contents of the lefthook.yaml file or remove it, as well as uninstall lefthook from the package.json file._
 
  i.e
 
  ```sh
- rm lefthook.yaml
- yarn remove lefthook
+ $ rm lefthook.yaml
+ $ yarn remove lefthook
  ```
 
 ### Branch naming conventions

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -14,12 +14,3 @@ pre-push:
         - merge
         - rebase
       run: ./.github/scripts/pin-version
-
-commit-msg:
-  parallel: true
-  commands:
-    commitlint:
-      skip:
-        - merge
-        - rebase
-      run: yarn commitlint --edit


### PR DESCRIPTION
No longer will lefthook check the commits on every commit, but instead we can control at the PR merge level.