### PR TITLE
feat: improve empty states for spec / doc rendering

### DIFF
--- a/cypress/e2e/specs/api_documentation.spec.ts
+++ b/cypress/e2e/specs/api_documentation.spec.ts
@@ -4,8 +4,9 @@ import documentTreeJSON from '../fixtures/dochub_mocks/documentTree.json'
 
 describe('Api Documentation Page', () => {
   beforeEach(() => {
+    product.document_count = 1
     cy.mockPrivatePortal()
-    cy.mockProduct(product.id)
+    cy.mockProduct(product.id, product)
     cy.mockGetProductDocumentBySlug(product.id, 'bar')
     cy.mockGetProductDocuments(product.id)
     cy.mockProductOperations()
@@ -14,6 +15,16 @@ describe('Api Documentation Page', () => {
 
   const PARENT_DOCUMENT_URL = `/docs/${product.id}/${documentTreeJSON[0].slug}`
   const CHILD_DOCUMENT_URL = `${PARENT_DOCUMENT_URL}/${documentTreeJSON[0].children[0].slug}`
+
+  it('displays empty state when no products', () => {
+    product.document_count = 0
+    cy.mockProduct(product.id, product)
+    cy.mockProductDocumentTree(product.id, { body: [] })
+    cy.visit(`/docs/${product.id}`)
+
+    cy.get('[data-testid="documentation-empty-state"]').should('be.visible')
+    cy.get('[data-testid="portal-document-viewer"]').should('not.exist')
+  })
 
   it('displays proper error message when 400', () => {
     cy.intercept(

--- a/src/components/product/Sidebar.vue
+++ b/src/components/product/Sidebar.vue
@@ -5,6 +5,12 @@
         <span class="title mb-5">
           {{ product?.name }}
         </span>
+        <KAlert
+          v-if="product && !versionSelectItems.length"
+          appearance="warning"
+          :alert-message="helpText.noVersions"
+          class="mb-4"
+        />
         <KSelect
           appearance="select"
           class="version-select-dropdown"

--- a/src/locales/ca_ES.ts
+++ b/src/locales/ca_ES.ts
@@ -175,6 +175,8 @@ export const ca_ES: I18nType = {
     isEmail: "L'adreça de correu electrònic ha de ser una adreça vàlida"
   },
   apiDocumentation: {
+    emptyTitle: 'This has not been translated',
+    emptyMessage: 'This has not been translated',
     error: {
       description: "S'ha produït un error inesperat en carregar el document sol·licitat.Si us plau, torneu- ho a provar més tard",
       linkText: 'Tornar a la pàgina inicial →'
@@ -187,6 +189,7 @@ export const ca_ES: I18nType = {
     linkText: 'Tornar a la pàgina inicial →'
   },
   sidebar: {
+    noVersions: 'This has not been translated',
     deprecated: ' (Desactivat)',
     noResultsProduct: 'Sense versions de producte'
   },

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -175,6 +175,8 @@ export const de: I18nType = {
     isEmail: 'E-Mail ist ungültig'
   },
   apiDocumentation: {
+    emptyTitle: 'This has not been translated',
+    emptyMessage: 'This has not been translated',
     error: {
       description: 'Ein unerwarteter Fehler ist aufgetreten, als versucht wurde, das angeforderte Dokument zu laden. Bitte versuchen Sie es später noch einmal',
       linkText: 'Zurück zum Start →'
@@ -187,6 +189,7 @@ export const de: I18nType = {
     linkText: 'Zurück zum Start →'
   },
   sidebar: {
+    noVersions: 'This has not been translated',
     deprecated: ' (Veraltet)',
     noResultsProduct: 'Keine Produktversionen'
   },

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -173,6 +173,8 @@ export const en = {
     isEmail: 'Email must be a valid email address'
   },
   apiDocumentation: {
+    emptyTitle: "No Documentation",
+    emptyMessage: "This product currently has no documentation. Reach out to your Developer Portal administrator if this is not expected.",
     error: {
       description: 'An unexpected error occurred when trying to load the requested document. Please try again later',
       linkText: 'Go back home →'
@@ -185,6 +187,7 @@ export const en = {
     linkText: 'Go back home →'
   },
   sidebar: {
+    noVersions: 'This product has no published product versions',
     deprecated: ' (Deprecated)',
     noResultsProduct: 'No product versions'
   },

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -173,8 +173,8 @@ export const en = {
     isEmail: 'Email must be a valid email address'
   },
   apiDocumentation: {
-    emptyTitle: "No Documentation",
-    emptyMessage: "This product currently has no documentation. Reach out to your Developer Portal administrator if this is not expected.",
+    emptyTitle: 'No Documentation',
+    emptyMessage: 'This product currently has no documentation. Reach out to your Developer Portal administrator if this is not expected.',
     error: {
       description: 'An unexpected error occurred when trying to load the requested document. Please try again later',
       linkText: 'Go back home →'

--- a/src/locales/es_ES.ts
+++ b/src/locales/es_ES.ts
@@ -175,6 +175,8 @@ export const es_ES: I18nType = {
     isEmail: 'El correo electrónico debe ser una dirección de correo electrónico válida'
   },
   apiDocumentation: {
+    emptyTitle: 'This has not been translated',
+    emptyMessage: 'This has not been translated',
     error: {
       description: 'Ocurrió un error inesperado al intentar cargar el documento. Por favor, inténtalo de nuevo más tarde',
       linkText: 'Regresar al inicio →'
@@ -187,6 +189,7 @@ export const es_ES: I18nType = {
     linkText: 'Regresar al inicio →'
   },
   sidebar: {
+    noVersions: 'This has not been translated',
     deprecated: ' (Obsoleto)',
     noResultsProduct: 'No hay versiones del producto'
   },

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -175,6 +175,8 @@ export const fr: I18nType = {
     isEmail: 'L\'adresse e-mail doit être valide'
   },
   apiDocumentation: {
+    emptyTitle: 'This has not been translated',
+    emptyMessage: 'This has not been translated',
     error: {
       description: 'Une erreur inattendue s\'est produite lors du chargement du document demandé. Veuillez réessayer ultérieurement.',
       linkText: 'Retourner à la page d\'accueil →'
@@ -187,6 +189,7 @@ export const fr: I18nType = {
     linkText: 'Retour à la page d\'accueil →'
   },
   sidebar: {
+    noVersions: 'This has not been translated',
     deprecated: ' (Obsolète)',
     noResultsProduct: 'Aucune version de produit'
   },

--- a/src/locales/i18n-type.d.ts
+++ b/src/locales/i18n-type.d.ts
@@ -173,6 +173,8 @@ export interface I18nType {
     isEmail: string;
   };
   apiDocumentation: {
+    emptyTitle: string,
+    emptyMessage: string,
     error: {
       description: string;
       linkText: string;
@@ -185,6 +187,7 @@ export interface I18nType {
     linkText: string;
   };
   sidebar: {
+    noVersions: string;
     deprecated: string;
     noResultsProduct: string;
   };

--- a/src/views/ApiDocumentationPage.vue
+++ b/src/views/ApiDocumentationPage.vue
@@ -5,7 +5,22 @@
     data-testid="api-documentation-page"
   >
     <div class="col content mt-6">
-      <KSkeleton v-if="isDocumentLoading" />
+      <div 
+        v-if="product && !product.document_count"
+        data-testid="documentation-empty-state"
+      >
+        <EmptyState>
+          <template #title>
+            {{ helpText.apiDocumentation.emptyTitle }}
+          </template>
+          <template #message>
+            <p>
+              {{ helpText.apiDocumentation.emptyMessage }}
+            </p>
+          </template>
+        </EmptyState>
+      </div>
+      <KSkeleton v-else-if="isDocumentLoading" />
       <template v-else>
         <header class="content-header">
           <KBreadcrumbs
@@ -24,6 +39,7 @@
         />
         <DocumentViewer
           v-else-if="content"
+          data-testid="portal-document-viewer"
           class="portal-document-viewer"
           :document="content"
         />
@@ -31,7 +47,7 @@
     </div>
     <aside class="col sidebar sidebar-sections">
       <KSkeleton
-        v-if="isDocumentLoading"
+        v-if="product?.document_count && isDocumentLoading"
         class="skeleton"
       />
       <DocumentSections

--- a/src/views/ApiDocumentationPage.vue
+++ b/src/views/ApiDocumentationPage.vue
@@ -5,7 +5,7 @@
     data-testid="api-documentation-page"
   >
     <div class="col content mt-6">
-      <div 
+      <div
         v-if="product && !product.document_count"
         data-testid="documentation-empty-state"
       >

--- a/src/views/Spec.vue
+++ b/src/views/Spec.vue
@@ -42,7 +42,7 @@
       :has-sidebar="false"
       :application-registration-enabled="applicationRegistrationEnabled"
       :active-operation="sidebarActiveOperationListItem"
-      :current-version="currentVersion.name"
+      :current-version="currentVersion?.name"
       @clicked-view-spec="triggerViewSpecModal"
       @clicked-register="triggerViewSpecRegistrationModal"
     />
@@ -115,7 +115,7 @@ export default defineComponent({
     ]
 
     const applicationRegistrationEnabled = computed(() => {
-      return currentVersion.value.registration_configs?.length && isAllowedToRegister.value
+      return spec.value.statusCode !== 404 && currentVersion.value.registration_configs?.length && isAllowedToRegister.value
     })
 
     const helpText = useI18nStore().state.helpText
@@ -170,7 +170,7 @@ export default defineComponent({
 
       await processProduct()
       await loadSwagger().then(() => {
-        if (sidebarOperations.value.length) {
+        if (sidebarOperations.value?.length) {
           // this means that user initially routed to a spec - check if
           // hash is present in route, if it is, we scroll to it
           const routeHash = $router.currentRoute.value?.hash
@@ -447,6 +447,9 @@ export default defineComponent({
         } catch (e) {
           console.error(e)
         }
+      } else {
+        // We want a 404 in the case that there is no product version spec
+        spec.value = { statusCode: 404 }
       }
     }
 


### PR DESCRIPTION
Updates to display an empty state for when a product version has no spec, as well as when a product has no product versions / documentation.

<img width="1023" alt="Screenshot 2023-08-02 at 12 56 37 PM" src="https://github.com/Kong/konnect-portal/assets/40131297/284d4714-5f7d-436d-b95c-c7d2c015c8cb">

<img width="1106" alt="Screenshot 2023-08-02 at 1 57 20 PM" src="https://github.com/Kong/konnect-portal/assets/40131297/74f0fd3b-1249-40a7-afc8-dfd5cd0e7b44">
