### PR TITLE
feat: add check for meta.public for public routes

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -201,7 +201,7 @@ export const portalRouter = () => {
     if (to.meta.public) {
       return next()
     }
-    
+
     const sessionDoesExist = session.exists()
 
     // check if needed refirect after SSO login to the page to which we tried access previously

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -198,6 +198,10 @@ export const portalRouter = () => {
 
   // check is authenticated developer
   router.beforeEach(async (to, from, next) => {
+    if (to.meta.public) {
+      return next()
+    }
+    
     const sessionDoesExist = session.exists()
 
     // check if needed refirect after SSO login to the page to which we tried access previously


### PR DESCRIPTION
This adds a check for a meta property in the router that will skip checking permissions / authorization if the `public` property exists on the route.

If you would to add a landing page (in the case that you have a private portal), you may add a new route like so:

```
          {
            path: '<PATH>',
            name: '<ROUTE_NAME>',
            meta: {
              title: Route Title,
              public: true
            },
            component: VueComponent
          },
```