### PR TITLE
refactor: redirect to 404 when spec is not found

### DIFF
--- a/src/views/ProductShell.vue
+++ b/src/views/ProductShell.vue
@@ -90,7 +90,16 @@ async function fetchProduct () {
 
     productStore.setProduct(productWithVersion)
   } catch (err) {
+    productStore.setProduct(null)
+
     console.error(err)
+
+    if (err.response?.status === 404) {
+      router.push({
+        name: 'not-found'
+      })
+    }
+
     productError.value = getMessageFromError(err)
   }
 }
@@ -105,9 +114,11 @@ async function fetchDocumentTree () {
     }
     // @ts-ignore
     // overriding the axios response because we're specifying what we're accepting above
-    const res = await documentationApi.listProductDocuments(requestOptions) as AxiosResponse<ListDocumentsTree, any>
+    if (productStore.product) {
+      const res = await documentationApi.listProductDocuments(requestOptions) as AxiosResponse<ListDocumentsTree, any>
 
-    productStore.setDocumentTree((res.data).data)
+      productStore.setDocumentTree((res.data).data)
+    }
   } catch (err) {
     if (err.response.status === 404) {
       productStore.setDocumentTree([])


### PR DESCRIPTION
The spec view would only show an error, but it should redirect to the 404 page if the spec is not found. In addition, it will not make the call to fetch documentation if there is no product.