### PR TITLE
chore: update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# URL for portal api
+# URL for portal api. Note URL must end with a trailing slash.
 VITE_PORTAL_API_URL='https://developer.konghq.com/'
 
 # Sets the localization, defaults to 'en' if unset


### PR DESCRIPTION
Add note in portal .env example file that the portal API URL must end in a trailing slash.