### PR TITLE
chore(analytics): remove feature flag [MA-2027]

### DIFF
--- a/cypress/e2e/specs/contextual-analytics.spec.ts
+++ b/cypress/e2e/specs/contextual-analytics.spec.ts
@@ -1,4 +1,4 @@
-import { apps, productRegistration, productRegistrations, versions } from '../fixtures/consts'
+import { apps, productRegistrations, versions } from '../fixtures/consts'
 
 describe('Contextual Developer Analytics', () => {
   beforeEach(() => {
@@ -21,9 +21,7 @@ describe('Contextual Developer Analytics', () => {
     viewAnalyticsButton: '[data-testid="application-dashboard-button"]'
   }
 
-  it('My Apps – displays displays metric cards if the feature flag is on', () => {
-    cy.mockLaunchDarklyFlags([{ name: 'ma-1002-dev-portal-contextual-analytics', value: true }])
-
+  it('My Apps – displays displays metric cards', () => {
     cy.mockApplications(apps, 4)
 
     cy.visit('/', { useOriginalFn: true })
@@ -36,38 +34,8 @@ describe('Contextual Developer Analytics', () => {
     cy.get(selectors.dashboardDropdownLink).should('exist')
   })
 
-  it('My Apps – does not display metric cards or the analytics dropdown link if the feature flag is off', () => {
-    cy.mockLaunchDarklyFlags([{ name: 'ma-1002-dev-portal-contextual-analytics', value: false }])
 
-    cy.mockApplications(apps, 5)
-    cy.visit('/my-apps')
-
-    cy.get(selectors.metricCardsParent).should('not.exist')
-    cy.get('[data-testid="applications-table"]').find('.actions-badge').first().click()
-    cy.get(selectors.dashboardDropdownLink).should('not.exist')
-  })
-
-  it('My App details page – does not display Metrics Card, View Analytics button if the feature flag is off', () => {
-    cy.mockLaunchDarklyFlags([{ name: 'ma-1002-dev-portal-contextual-analytics', value: true }])
-    cy.mockApplications(apps, 4)
-
-    cy.intercept(
-      'GET',
-      `**/api/v2/applications/${apps[0].id}`, {
-        statusCode: 200,
-        body: { ...apps[0] }
-      }
-    ).as('getSingleApplication')
-
-    cy.mockApplicationWithCredAndReg(apps[0])
-
-    cy.visit(`/application/${apps[0].id}`)
-    cy.get('[data-testid="analytics-metric-cards"]').should('not.exist')
-    cy.get('[data-testid="application-dashboard-button"]').should('not.exist')
-  })
-
-  it('App Dashboard - vitals elements load when contextual analytics feature flag is on', () => {
-    cy.mockLaunchDarklyFlags([{ name: 'ma-1002-dev-portal-contextual-analytics', value: true }])
+  it('App Dashboard - vitals elements load', () => {
     cy.mockApplications(apps, 4)
 
     cy.intercept('GET', `**/api/v2/applications/${apps[0].id}`, {

--- a/src/constants/feature-flags.ts
+++ b/src/constants/feature-flags.ts
@@ -1,3 +1,3 @@
 export enum FeatureFlags {
-  PortalContextualAnalytics = 'ma-1002-dev-portal-contextual-analytics'
+  //
 }

--- a/src/views/Applications/ApplicationDashboard.vue
+++ b/src/views/Applications/ApplicationDashboard.vue
@@ -17,7 +17,7 @@
         class="mb-5"
         :title="helpText.analytics.dashboard"
       />
-      <div v-if="contextualAnalytics && hasProductVersions">
+      <div v-if="hasProductVersions">
         <div
           class="analytics-filters d-flex flex-grow-1 justify-content-between align-items-baseline mb-6"
         >
@@ -112,8 +112,6 @@ import getMessageFromError from '@/helpers/getMessageFromError'
 import usePortalApi from '@/hooks/usePortalApi'
 import useToaster from '@/composables/useToaster'
 import useAllowedTimeframes from '@/composables/useAllowedTimeframes'
-import { FeatureFlags } from '@/constants/feature-flags'
-import useLDFeatureFlag from '@/hooks/useLDFeatureFlag'
 import {
   datePickerSelectionToTimeframe,
   Timeframe,
@@ -130,9 +128,6 @@ import PageTitle from '@/components/PageTitle.vue'
 import { useAppStore, useI18nStore } from '@/stores'
 import cloneDeep from 'lodash.clonedeep'
 import { PortalTimeframeKeys } from '@/types/vitals'
-
-// @ts-ignore
-const contextualAnalytics = useLDFeatureFlag(FeatureFlags.PortalContextualAnalytics, false)
 
 const { notify } = useToaster()
 const errorMessage = ref('')

--- a/src/views/MyApps.vue
+++ b/src/views/MyApps.vue
@@ -32,7 +32,7 @@
       </template>
     </PageTitle>
     <div
-      v-if="contextualAnalytics && !vitalsLoading && myAppsReady"
+      v-if="!vitalsLoading && myAppsReady"
     >
       <MetricsProvider
         v-slot="{ timeframe }"
@@ -76,7 +76,6 @@
               <ActionsDropdown :key="row.id">
                 <template #content>
                   <div
-                    v-if="contextualAnalytics"
                     data-testid="dropdown-analytics-dashboard"
                     class="py-2 px-3 type-md cursor-pointer"
                     @click="$router.push({ name: 'application-dashboard', params: { application_id: row.id }})"
@@ -182,8 +181,6 @@
 import { defineComponent, computed, ref, onMounted } from 'vue'
 import { useMachine } from '@xstate/vue'
 import { createMachine } from 'xstate'
-import { FeatureFlags } from '@/constants/feature-flags'
-import useLDFeatureFlag from '@/hooks/useLDFeatureFlag'
 import getMessageFromError from '@/helpers/getMessageFromError'
 import RefreshTokenModal from '@/components/RefreshTokenModal.vue'
 import PageTitle from '@/components/PageTitle.vue'
@@ -218,9 +215,6 @@ export default defineComponent({
     const helpText = useI18nStore().state.helpText.myApp
     const helpTextVitals = useI18nStore().state.helpText.analytics
     const vitalsLoading = ref(true)
-
-    // @ts-ignore: Dev Portal doesn't have TS for feature flags.
-    const contextualAnalytics = useLDFeatureFlag(FeatureFlags.PortalContextualAnalytics, false)
 
     const paginationConfig = ref({
       paginationPageSizes: [25, 50, 100],
@@ -365,7 +359,6 @@ export default defineComponent({
       helpText,
       helpTextVitals,
       analyticsCardTitle,
-      contextualAnalytics,
       vitalsLoading,
       metricProviderProps,
       myAppsReady


### PR DESCRIPTION

https://konghq.atlassian.net/browse/MA-2027

Made sure that setting `VITE_ENABLE_LAUNCH_DARKLY=false` still loads all vitals' elements across all the pages (eg:  metric cards & charts)