### PR TITLE
chore(docs): update status badges to use actions that run on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The [Konnect Dev Portal][konnect-docs-url] is a web application for developers t
 
 In [Kong Konnect][kong-konnect-register-url], you have two hosting options for the Dev Portal web user interface: a cloud hosted Dev Portal with Konnect or a self-hosted, open source Dev Portal powered by Konnect APIs.
 
+Check out the [example app][https://konnect-portal.konghq.com/] to get an idea of what this client app looks like out-of-the-box.
+
 ## Self-hosted Dev Portal benefits
 
 There are several benefits to keep in mind when deciding whether to use a Konnect-hosted or self-hosted Dev Portal. The self-hosted portal provides the following benefits:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Stars](https://img.shields.io/github/stars/Kong/konnect-portal?style=flat-square)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/Kong/konnect-portal?style=flat-square)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
-[![Deploy Preview](https://github.com/Kong/konnect-portal/actions/workflows/github-pages.yml/badge.svg?branch=main)](https://github.com/Kong/konnect-portal/actions/workflows/github-pages.yml)
+[![Deploy Example App](https://github.com/Kong/konnect-portal/actions/workflows/github-pages.yml/badge.svg?branch=main)](https://github.com/Kong/konnect-portal/actions/workflows/github-pages.yml)
 [![Semantic Release](https://github.com/Kong/konnect-portal/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/Kong/konnect-portal/actions/workflows/release.yml)
 ![License](https://img.shields.io/badge/License-Apache%202.0-blue?style=flat-square)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ![Stars](https://img.shields.io/github/stars/Kong/konnect-portal?style=flat-square)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/Kong/konnect-portal?style=flat-square)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
-[![Tests](https://github.com/Kong/konnect-portal/actions/workflows/pr.yml/badge.svg)](https://github.com/Kong/konnect-portal/actions/workflows/pr.yml)
+[![Deploy Preview](https://github.com/Kong/konnect-portal/actions/workflows/github-pages.yml/badge.svg?branch=main)](https://github.com/Kong/konnect-portal/actions/workflows/github-pages.yml)
+[![Semantic Release](https://github.com/Kong/konnect-portal/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/Kong/konnect-portal/actions/workflows/release.yml)
 ![License](https://img.shields.io/badge/License-Apache%202.0-blue?style=flat-square)
 
 ![Twitter Follow](https://img.shields.io/twitter/follow/thekonginc?style=social)


### PR DESCRIPTION
The status badge in the README was pointing to a Github action that runs on PR branches, not main. This swaps the badges to show two actions that run on main.