### PR TITLE
feat: hide spec link in catalog if no versions

### DIFF
--- a/cypress/e2e/specs/catalog.spec.ts
+++ b/cypress/e2e/specs/catalog.spec.ts
@@ -1,4 +1,4 @@
-import { SearchResults, SearchResultsDataInner } from '@kong/sdk-portal-js'
+import { ProductCatalogIndexSourceLatestVersion, SearchResults, SearchResultsDataInner } from '@kong/sdk-portal-js'
 import { generateProducts } from '../support/utils/generateProducts'
 
 const mockProductSearchQuery = (searchQuery: string) => {
@@ -72,6 +72,7 @@ describe('Catalog', () => {
     cy.mockStylesheetFont()
     cy.mockAppearance()
     cy.mockStylesheetCss()
+    cy.mockProductVersionSpec()
   })
 
   describe('Catalog card view', () => {
@@ -113,6 +114,16 @@ describe('Catalog', () => {
       cy.url().should('include', '/spec')
     })
 
+    it('does not render specification link if no latest version', () => {
+      cy.mockPublicPortal()
+      cy.mockProduct()
+      cy.mockProductsCatalog(1, [{ description: 'great description', latest_version: null as ProductCatalogIndexSourceLatestVersion }])
+
+      cy.visit('/')
+
+      cy.get('.catalog-item .link').should('not.exist')
+    })
+
     it('displays an empty state with no products', () => {
       cy.mockPublicPortal()
       cy.mockProductsCatalog(0)
@@ -132,11 +143,11 @@ describe('Catalog', () => {
       cy.get('[data-testid="view-switcher"]').should('be.disabled')
     })
 
-    it('renders the documentation link for catalog item', () => {
+    it('does not render the documentation link for catalog item if no documents', () => {
       cy.mockPrivatePortal()
-      cy.mockProductsCatalog(1, [{ description: 'great description', document_count: 2 }])
+      cy.mockProductsCatalog(1, [{ description: 'great description' }])
       cy.visit('/')
-      cy.get('.catalog-item .link').contains('Documentation').should('exist')
+      cy.get('.catalog-item .link').contains('Documentation').should('not.exist')
     })
   })
 

--- a/cypress/e2e/specs/catalog.spec.ts
+++ b/cypress/e2e/specs/catalog.spec.ts
@@ -143,6 +143,13 @@ describe('Catalog', () => {
       cy.get('[data-testid="view-switcher"]').should('be.disabled')
     })
 
+    it('renders the documentation link for catalog item', () => {
+      cy.mockPrivatePortal()
+      cy.mockProductsCatalog(1, [{ description: 'great description', document_count: 2 }])
+      cy.visit('/')
+      cy.get('.catalog-item .link').contains('Documentation').should('exist')
+    })
+
     it('does not render the documentation link for catalog item if no documents', () => {
       cy.mockPrivatePortal()
       cy.mockProductsCatalog(1, [{ description: 'great description' }])

--- a/src/components/CatalogItem.vue
+++ b/src/components/CatalogItem.vue
@@ -53,7 +53,10 @@
           </span>
         </li>
         <li class="docs-links">
-          <div class="details-item">
+          <div
+            v-if="product.versionCount"
+            class="details-item"
+          >
             <template v-if="loading">
               <KSkeletonBox width="50" />
             </template>

--- a/src/components/CatalogItem.vue
+++ b/src/components/CatalogItem.vue
@@ -54,7 +54,7 @@
         </li>
         <li class="docs-links">
           <div
-            v-if="product.versionCount"
+            v-if="product.showSpecLink"
             class="details-item"
           >
             <template v-if="loading">

--- a/src/components/CatalogTableList.vue
+++ b/src/components/CatalogTableList.vue
@@ -28,7 +28,7 @@
       </template>
       <template #links="{ row }">
         <router-link
-          v-if="row.versionCount"
+          v-if="row.showSpecLink"
           :to="{ name: 'spec', params: { product: row.id } }"
           class="link"
         >

--- a/src/components/CatalogTableList.vue
+++ b/src/components/CatalogTableList.vue
@@ -28,6 +28,7 @@
       </template>
       <template #links="{ row }">
         <router-link
+          v-if="row.versionCount"
           :to="{ name: 'spec', params: { product: row.id } }"
           class="link"
         >

--- a/src/stores/product.ts
+++ b/src/stores/product.ts
@@ -9,6 +9,7 @@ export interface ProductWithVersions extends Product {
 export interface CatalogItemModel {
   id: string;
   title: string;
+  showSpecLink: boolean;
   latestVersion: null|{ name: string; id: string}
   description: string;
   documentCount: number;


### PR DESCRIPTION
This hides the specification link in the catalog for a product - if there are no versions for that product.