### PR TITLE
fix: correct document tree request header

### DIFF
--- a/src/views/ProductShell.vue
+++ b/src/views/ProductShell.vue
@@ -109,13 +109,16 @@ async function fetchDocumentTree () {
 
   try {
     const requestOptions = {
-      productId: id,
-      accept: DocumentContentTypeEnum.VndKonnectDocumentTreejson
+      productId: id
     }
     // @ts-ignore
     // overriding the axios response because we're specifying what we're accepting above
     if (productStore.product) {
-      const res = await documentationApi.listProductDocuments(requestOptions) as AxiosResponse<ListDocumentsTree, any>
+      const res = await documentationApi.listProductDocuments(requestOptions, {
+        headers: {
+          accept: DocumentContentTypeEnum.VndKonnectDocumentTreejson
+        }
+      }) as AxiosResponse<ListDocumentsTree, any>
 
       productStore.setDocumentTree((res.data).data)
     }


### PR DESCRIPTION
Correctly updates the request to pass in the accept header which resolves the issue of incorrect document ordering