### PR TITLE
style(appreg): adjust style for scopes selection

### DIFF
--- a/src/components/ViewSpecRegistrationModal.vue
+++ b/src/components/ViewSpecRegistrationModal.vue
@@ -67,7 +67,7 @@
                   class="available-scopes-select"
                   :items="mappedAvailableScopes"
                   :loading="fetchingScopes"
-                  :placeholder="fetchingScopes ? helpText.applicationRegistration.fetchingScopesLabel : helpText.applicationRegistration.availableScopesLabel"
+                  :placeholder="fetchingScopes ? helpText.applicationRegistration.fetchingScopesLabel : helpText.applicationRegistration.filterScopes"
                   width="100%"
                   @change="handleChangedItem"
                 />

--- a/src/components/ViewSpecRegistrationModal.vue
+++ b/src/components/ViewSpecRegistrationModal.vue
@@ -432,14 +432,7 @@ export default defineComponent({
 
  .application-registration-modal {
   :deep(.selected) {
-    background-color: var(--text_colors-accent) !important;
-
-    td {
-      color: var(--section_colors-body) !important;
-    }
-
     .k-input-label {
-      color: var(--section_colors-body);
       font-weight: 600;
       width: 100%;
     }
@@ -472,6 +465,17 @@ export default defineComponent({
       margin-top: 4rem;
       margin-bottom: 0;
       max-width: 750px;
+
+      .k-multiselect {
+        .k-multiselect-icon .k-multiselect-clear-icon {
+          top: 21px;
+        }
+
+        .k-multiselect-selections {
+          display: flex;
+          flex-wrap: wrap;
+        }
+      }
     }
   }
   .k-table-toolbar {

--- a/src/locales/ca_ES.ts
+++ b/src/locales/ca_ES.ts
@@ -187,6 +187,7 @@ export const ca_ES: I18nType = {
     noAvailableApplications: 'Actualment no teniu cap aplicació per registrar.',
     noFoundApplications: translationNeeded(en.applicationRegistration.noFoundApplications),
     searchPlaceholder: translationNeeded(en.applicationRegistration.searchPlaceholder),
+    filterScopes: translationNeeded(en.applicationRegistration.filterScopes),
     availableScopesLabel: translationNeeded(en.applicationRegistration.availableScopesLabel),
     fetchingScopesLabel: translationNeeded(en.applicationRegistration.fetchingScopesLabel),
     noApplications: 'Sense aplicacions',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -187,6 +187,7 @@ export const de: I18nType = {
     noAvailableApplications: 'Aktuell haben Sie noch keine Applikationen registriert.',
     noFoundApplications: translationNeeded(en.applicationRegistration.noFoundApplications),
     searchPlaceholder: translationNeeded(en.applicationRegistration.searchPlaceholder),
+    filterScopes: translationNeeded(en.applicationRegistration.filterScopes),
     availableScopesLabel: translationNeeded(en.applicationRegistration.availableScopesLabel),
     fetchingScopesLabel: translationNeeded(en.applicationRegistration.fetchingScopesLabel),
     noApplications: 'Keine Applikationen',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -188,6 +188,7 @@ export const en = {
     createApplication: 'Create an Application',
     searchPlaceholder: 'Search applications',
     cancelButton: 'Cancel',
+    filterScopes: 'filter...',
     availableScopesLabel: 'Select scopes',
     fetchingScopesLabel: 'Fetching scopes...',
     registeredApplicationsProduct: 'The following applications are already registered to this product:',

--- a/src/locales/es_ES.ts
+++ b/src/locales/es_ES.ts
@@ -187,6 +187,7 @@ export const es_ES: I18nType = {
     noAvailableApplications: 'Actualmente no hay aplicaciones disponibles para registrarse.',
     noFoundApplications: translationNeeded(en.applicationRegistration.noFoundApplications),
     searchPlaceholder: translationNeeded(en.applicationRegistration.searchPlaceholder),
+    filterScopes: translationNeeded(en.applicationRegistration.filterScopes),
     availableScopesLabel: translationNeeded(en.applicationRegistration.availableScopesLabel),
     fetchingScopesLabel: translationNeeded(en.applicationRegistration.fetchingScopesLabel),
     noApplications: 'No hay aplicaciones',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -187,6 +187,7 @@ export const fr: I18nType = {
     noAvailableApplications: 'Vous n\'avez actuellement aucune application à enregistrer.',
     noFoundApplications: translationNeeded(en.applicationRegistration.noFoundApplications),
     searchPlaceholder: translationNeeded(en.applicationRegistration.searchPlaceholder),
+    filterScopes: translationNeeded(en.applicationRegistration.filterScopes),
     availableScopesLabel: translationNeeded(en.applicationRegistration.availableScopesLabel),
     fetchingScopesLabel: translationNeeded(en.applicationRegistration.fetchingScopesLabel),
     noApplications: 'Aucune application',

--- a/src/locales/i18n-type.d.ts
+++ b/src/locales/i18n-type.d.ts
@@ -191,6 +191,7 @@ export interface I18nType {
     registeredApplicationsProduct: string;
     searchPlaceholder: string;
     availableScopesLabel: string;
+    filterScopes: string;
     modalApplicationRegistrationDefault: {
       title: (serviceName: string, productVersion: string) => string;
       buttonText: string;


### PR DESCRIPTION
This PR Adjusts the styling of the Auth0 Developer Managed scopes modal:

- remove the background color
- adjust the position of the "X" close button
- left aligns and fixes overflow of selected scopes
- Changes place holder copy in the filter input to "filter..." 

<img width="749" alt="image" src="https://github.com/Kong/konnect-portal/assets/5304468/68ac8727-1ec2-4fa1-b5bc-0bf44f60aaae">
