### PR TITLE
feat: disable new apps if no auth strategies and display banner

### DIFF
--- a/cypress/e2e/specs/application_registration.spec.ts
+++ b/cypress/e2e/specs/application_registration.spec.ts
@@ -215,6 +215,65 @@ describe('Application Registration', () => {
 
       cy.get('[data-testid="reference-id-input"]').should('not.have.value', '')
     })
+
+    it('appregv2 - create application form shows banner if no auth strategies and flag enabled', () => {
+      cy.mockLaunchDarklyFlags([
+        {
+          name: 'tdx-3531-app-reg-v2',
+          value: true
+        }
+      ])
+      cy.mockApplicationAuthStrategies([], 0)
+      cy.visit('/application/create')
+
+      cy.get('[data-testid="application-name-input"]').type(apps[0].name, { delay: 0 })
+      cy.get('#description').type(apps[0].description, { delay: 0 })
+      cy.get('[data-testid="reference-id-input"]').type(apps[0].reference_id, { delay: 0 })
+      cy.get(submitButton).should('be.disabled')
+      cy.get('[data-testid="no-auth-strategies-warning"]').should('be.visible')
+    })
+
+    it('appregv2 - create application form does not show banner if flag disabled', () => {
+      cy.mockLaunchDarklyFlags([
+        {
+          name: 'tdx-3531-app-reg-v2',
+          value: false
+        }
+      ])
+      cy.mockApplicationAuthStrategies([], 0)
+      cy.visit('/application/create')
+
+      cy.get('[data-testid="no-auth-strategies-warning"]').should('not.exist')
+    })
+    it('appregv2 - does not show warning banner if flag is not on', () => {
+      cy.mockLaunchDarklyFlags([
+        {
+          name: 'tdx-3531-app-reg-v2',
+          value: false
+        }
+      ])
+      cy.mockApplications([], 0)
+      cy.mockApplicationAuthStrategies([], 0)
+      cy.visit('/my-apps')
+
+      cy.get('[data-testid="create-application-button"]').should('not.be.disabled')
+      cy.get('[data-testid="no-auth-strategies-warning"]').should('not.exist')
+    })
+
+    it('appregv2 - shows warning banner if no available auth strategies', () => {
+      cy.mockLaunchDarklyFlags([
+        {
+          name: 'tdx-3531-app-reg-v2',
+          value: true
+        }
+      ])
+      cy.mockApplications([], 0)
+      cy.mockApplicationAuthStrategies([], 0)
+      cy.visit('/my-apps')
+
+      cy.get('[data-testid="create-application-button"]').should('have.attr', 'disabled', 'disabled')
+      cy.get('[data-testid="no-auth-strategies-warning"]').should('be.visible')
+    })
   })
 
   it('can return to My Apps from application details via breadcrumb', () => {

--- a/cypress/e2e/support/index.ts
+++ b/cypress/e2e/support/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 // Import commands.js using ES2015 syntax:
-import { GetApplicationResponse, GetRegistrationResponse, ListCredentialsResponseDataInner, PortalAppearance, PortalContext, Product, ProductCatalogIndexSource, ProductVersion, ProductVersionSpecOperationsOperationsInner } from '@kong/sdk-portal-js'
+import { GetApplicationResponse, GetRegistrationResponse, ListAuthStrategiesItem, ListCredentialsResponseDataInner, PortalAppearance, PortalContext, Product, ProductCatalogIndexSource, ProductVersion, ProductVersionSpecOperationsOperationsInner } from '@kong/sdk-portal-js'
 import './mock-commands'
 import { SinonStub } from 'cypress/types/sinon'
 
@@ -26,6 +26,7 @@ declare global {
       mockProduct(productId?: string, mockProduct?: Product, mockVersions?: ProductVersion[]): Chainable<JQuery<HTMLElement>>
       mockProductVersion(productId?: string, versionId?: string, mockVersion?: ProductVersion): Chainable<JQuery<HTMLElement>>
       mockApplications(searchResults?: Array<GetApplicationResponse>, totalCount?: number, pageSize?: number, pageNumber?: number): Chainable<JQuery<HTMLElement>>
+      mockApplicationAuthStrategies(authStrategyItems?: Array<ListAuthStrategiesItem>, totalCount?: number, pageSize?: number, pageNumber?: number): Chainable<JQuery<HTMLElement>>
       mockApplicationWithCredAndReg(data: GetApplicationResponse, credentials?: ListCredentialsResponseDataInner[], registrations?: Array<GetRegistrationResponse>): Chainable<JQuery<HTMLElement>>,
       mockContextualAnalytics(): Chainable<JQuery<HTMLElement>>
       mockRegistrations(applicationId?: string, registrations?: Array<GetRegistrationResponse>, totalCount?: number): Chainable<JQuery<HTMLElement>>

--- a/cypress/e2e/support/mock-commands.ts
+++ b/cypress/e2e/support/mock-commands.ts
@@ -10,6 +10,7 @@ import petstoreOperationsV2 from '../fixtures/v2/petstoreOperations.json'
 import {
   GetApplicationResponse,
   ListApplicationsResponse,
+  ListAuthStrategiesResponse,
   ListCredentialsResponse,
   ListDocumentsTree,
   ListRegistrationsResponse,
@@ -331,6 +332,24 @@ Cypress.Commands.add('mockApplications', (applications, totalCount, pageSize = 1
   return cy.intercept('GET', '**/api/v2/applications*', {
     body: responseBody
   }).as('getApplications')
+})
+
+Cypress.Commands.add('mockApplicationAuthStrategies', (applicationAuthStrategies, totalCount, pageSize = 1, pageNumber = 10) => {
+  const responseBody: ListAuthStrategiesResponse = {
+    data: applicationAuthStrategies,
+    meta: {
+      page: {
+        total: totalCount,
+        number: pageNumber,
+        size: pageSize
+
+      }
+    }
+  }
+
+  return cy.intercept('GET', '**/api/v2/applications/auth-strategies*', {
+    body: responseBody
+  }).as('getApplicationAuthStrategies')
 })
 
 Cypress.Commands.add('mockRegistrations', (applicationId = '*', registrations = [], pageNumber = 1, pageSize = 10, totalCount = 0) => {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@kong-ui-public/spec-renderer": "0.13.5",
     "@kong/kong-auth-elements": "2.11.1",
     "@kong/kongponents": "8.127.0",
-    "@kong/sdk-portal-js": "2.5.0",
+    "@kong/sdk-portal-js": "2.6.1",
     "@xstate/vue": "2.0.0",
     "axios": "1.6.0",
     "date-fns": "3.3.0",

--- a/src/constants/feature-flags.ts
+++ b/src/constants/feature-flags.ts
@@ -1,3 +1,4 @@
 export enum FeatureFlags {
-  DeveloperManagedScopes = 'tdx-3460-developer-managed-scopes'
+  DeveloperManagedScopes = 'tdx-3460-developer-managed-scopes',
+  AppRegV2 = 'tdx-3531-app-reg-v2'
 }

--- a/src/locales/ca_ES.ts
+++ b/src/locales/ca_ES.ts
@@ -103,6 +103,7 @@ export const ca_ES: I18nType = {
     delete: 'Eliminar',
     proceed: 'Continuar',
     applicationName: "Nom de l'aplicació ",
+    authStrategyWarning: translationNeeded(en.application.authStrategyWarning),
     clientID: 'ID de client: ',
     clientSecret: 'Clau secreta de client: ',
     reqField: ' indica un camp obligatori',
@@ -285,6 +286,7 @@ export const ca_ES: I18nType = {
     logoAlt: 'logotip'
   },
   myApp: {
+    authStrategyWarning: translationNeeded(en.application.authStrategyWarning),
     newApp: 'Nova aplicació',
     plus: 'Més',
     myApps: 'Les meves aplicacions',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -103,6 +103,7 @@ export const de: I18nType = {
     delete: 'Löschen',
     proceed: 'Weiter',
     applicationName: 'Name der Applikation',
+    authStrategyWarning: translationNeeded(en.application.authStrategyWarning),
     clientID: translationNeeded(en.application.clientID),
     clientSecret: translationNeeded(en.application.clientSecret),
     reqField: ' Pflichtfeld',
@@ -285,6 +286,7 @@ export const de: I18nType = {
     logoAlt: 'Logo'
   },
   myApp: {
+    authStrategyWarning: translationNeeded(en.application.authStrategyWarning),
     newApp: 'Neue Applikation',
     plus: 'Plus',
     myApps: 'Meine Applikationen',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -99,6 +99,7 @@ export const en = {
     delete: 'Delete',
     proceed: 'Proceed',
     applicationName: 'Application Name ',
+    authStrategyWarning: 'You cannot create an application as this developer portal has no available application auth strategies. Please contact a developer portal admin.',
     clientID: 'Client ID: ',
     clientSecret: 'Client Secret: ',
     reqField: ' indicates required field',
@@ -281,6 +282,7 @@ export const en = {
     logoAlt: 'logo'
   },
   myApp: {
+    authStrategyWarning: 'You cannot create an application as this developer portal has no available application auth strategies. Please contact a developer portal admin.',
     newApp: 'New App',
     plus: 'Plus',
     myApps: 'My Apps',

--- a/src/locales/es_ES.ts
+++ b/src/locales/es_ES.ts
@@ -103,6 +103,7 @@ export const es_ES: I18nType = {
     delete: 'Eliminar',
     proceed: 'Continuar',
     applicationName: 'Nombre de la aplicación ',
+    authStrategyWarning: translationNeeded(en.application.authStrategyWarning),
     clientID: 'ID de cliente: ',
     clientSecret: 'Clave secreta de cliente: ',
     reqField: ' indica campo obligatorio',
@@ -285,6 +286,7 @@ export const es_ES: I18nType = {
     logoAlt: 'logo'
   },
   myApp: {
+    authStrategyWarning: translationNeeded(en.application.authStrategyWarning),
     newApp: 'Nueva aplicación',
     plus: 'Plus',
     myApps: 'Mis aplicaciones',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -103,6 +103,7 @@ export const fr: I18nType = {
     delete: 'Supprimer',
     proceed: 'Continuer',
     applicationName: 'Nom de l\'application ',
+    authStrategyWarning: translationNeeded(en.application.authStrategyWarning),
     clientID: 'Client ID : ',
     clientSecret: 'Client Secret : ',
     reqField: ' indique un champ obligatoire',
@@ -285,6 +286,7 @@ export const fr: I18nType = {
     logoAlt: 'logo'
   },
   myApp: {
+    authStrategyWarning: translationNeeded(en.application.authStrategyWarning),
     newApp: 'Nouvelle application',
     plus: 'Plus',
     myApps: 'Mes applications',

--- a/src/locales/i18n-type.d.ts
+++ b/src/locales/i18n-type.d.ts
@@ -99,6 +99,7 @@ export interface I18nType {
     delete: string;
     proceed: string;
     applicationName: string;
+    authStrategyWarning: string;
     clientID: string;
     clientSecret: string;
     reqField: string;
@@ -281,6 +282,7 @@ export interface I18nType {
     logoAlt: string;
   };
   myApp: {
+    authStrategyWarning: string;
     newApp: string;
     plus: string;
     myApps: string;

--- a/src/views/Applications/ApplicationForm.vue
+++ b/src/views/Applications/ApplicationForm.vue
@@ -315,8 +315,10 @@ export default defineComponent({
             hasAppAuthStrategies.value = true
           }
         } catch (err) {
-          // eslint-disable-next-line no-console
-          console.warn(`Error fetching application auth strategies: ${err}`)
+          notify({
+            appearance: 'danger',
+            message: `Error fetching application auth strategies: ${err}`
+          })
         }
       }
     })

--- a/src/views/MyApps.vue
+++ b/src/views/MyApps.vue
@@ -374,8 +374,10 @@ export default defineComponent({
             hasAppAuthStrategies.value = true
           }
         } catch (err) {
-          // eslint-disable-next-line no-console
-          console.warn(`Error fetching application auth strategies: ${err}`)
+          notify({
+            appearance: 'danger',
+            message: `Error fetching application auth strategies: ${err}`
+          })
         }
       }
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1121,10 +1121,10 @@
     v-calendar "3.0.0-alpha.8"
     vue-draggable-next "^2.2.1"
 
-"@kong/sdk-portal-js@2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@kong/sdk-portal-js/-/sdk-portal-js-2.5.0.tgz#bfa53c3fcb0fbd63cb54eea2e73443a34fab3fa6"
-  integrity sha512-nt74ub5WpLF2Vh/dVeHIycccaNr9wVOfcvDaGnoccfH41Pi5jtBa/5lJSEG2hMSRloRVAX8J6TRWT5vHNYCiKg==
+"@kong/sdk-portal-js@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@kong/sdk-portal-js/-/sdk-portal-js-2.6.1.tgz#b855a505c0166825fcd4494f385a61bd7e5039e6"
+  integrity sha512-Q5Vcw57j48F+ujhGgtbTWyvshZBJgX/VKoZgEeRiJABAdfN7Td9CB+8UCAvK2uhk4kB0lzh/HCVqv9kCD1IhAQ==
   dependencies:
     axios "1.6.0"
 


### PR DESCRIPTION
Shows a banner if you have no available auth strategies, and disables the button to create / view the new app form.