### PR TITLE
feat(app-reg-v2): filter applications by auth_strategy_id

### DIFF
--- a/cypress/e2e/fixtures/consts.ts
+++ b/cypress/e2e/fixtures/consts.ts
@@ -1,4 +1,4 @@
-import { GetApplicationResponse, GetRegistrationResponse, PortalContext, Product, ProductVersion } from '@kong/sdk-portal-js'
+import { GetApplicationResponse, GetRegistrationResponse, PortalContext, Product, ProductVersion, RegistrationConfiguration } from '@kong/sdk-portal-js'
 
 const versions: ProductVersion[] = [
   {
@@ -11,14 +11,23 @@ const versions: ProductVersion[] = [
   }
 ]
 
+const keyAuthRegConfig: RegistrationConfiguration = {
+  name: 'key auth auth strategy',
+  credential_type: 'key_auth',
+  id: 'd668b397-8a0d-482d-9b97-9e05cbfc7618'
+}
+
+const oidcAuthRegConfig: RegistrationConfiguration = {
+  auth_methods: ['bearer', 'client_credentials'],
+  name: 'oidc auth strategy',
+  credential_type: 'client_credentials',
+  id: '7b651144-0b48-431a-af9b-58604adc9268'
+}
+
 const versionWithOidcAuthStrategy: ProductVersion = {
   ...versions[0],
   registration_configs: [
-    {
-      auth_methods: ['bearer', 'client_credentials'],
-      name: 'oidc auth strategy',
-      credential_type: 'client_credentials'
-    }
+    oidcAuthRegConfig
   ]
 }
 
@@ -29,10 +38,7 @@ const versionWithKeyAuthAuthStrategy: ProductVersion = {
   name: 'v1-beta',
   deprecated: false,
   registration_configs: [
-    {
-      name: 'key auth auth strategy',
-      credential_type: 'key_auth'
-    }
+    keyAuthRegConfig
   ]
 }
 
@@ -46,6 +52,34 @@ const product: Product = {
   latest_version: {
     id: versions[0].id,
     name: versions[0].name
+  },
+  version_count: 1
+}
+
+export const productWithKeyAuthAppAuthStrategy: Product = {
+  created_at: '2022-03-23T14:52:41.893Z',
+  updated_at: '2022-03-23T14:52:41.893Z',
+  id: '29985c03-a866-46f2-8152-29406243b90f',
+  name: 'barAPI',
+  description: null,
+  document_count: 0,
+  latest_version: {
+    id: versionWithKeyAuthAuthStrategy.id,
+    name: versionWithKeyAuthAuthStrategy.name
+  },
+  version_count: 1
+}
+
+export const productWithOidcAppAuthStrategy: Product = {
+  created_at: '2024-03-23T14:52:41.893Z',
+  updated_at: '2024-03-23T14:52:41.893Z',
+  id: '7b5f7176-bbb1-4e98-bb98-fa16ae492b64',
+  name: 'fooAPI',
+  description: null,
+  document_count: 0,
+  latest_version: {
+    id: versionWithOidcAuthStrategy.id,
+    name: versionWithOidcAuthStrategy.name
   },
   version_count: 1
 }
@@ -90,6 +124,17 @@ const apps: GetApplicationResponse[] = [
     updated_at: '2022-03-25T13:15:02.104Z'
   }
 ]
+
+export const appWithAuthStrategy: GetApplicationResponse = {
+  name: 'My Key-Auth App',
+  description: 'My DCR App has an auth strategy id',
+  reference_id: '5',
+  redirect_uri: 'http://google.com',
+  id: crypto.randomUUID(),
+  created_at: '2022-03-25T13:15:02.104Z',
+  updated_at: '2022-03-25T13:15:02.104Z',
+  auth_strategy_id: '452664ba-7d37-4e12-875c-3ca8044446fd'
+}
 
 const productRegistration: GetRegistrationResponse = {
   created_at: '2022-03-25T13:15:02.104Z',

--- a/cypress/e2e/support/mock-commands.ts
+++ b/cypress/e2e/support/mock-commands.ts
@@ -277,11 +277,11 @@ Cypress.Commands.add('mockProduct', (productId = '*', mockProduct = product, moc
     }
   }
 
-  cy.intercept('GET', `**/api/v2/products/${productId}/versions*`, {
+  cy.intercept('GET', `**/api/v2/products/${productId}/versions**`, {
     statusCode: 200,
     delay: 100,
     body: versionsResponse
-  })
+  }).as('getProductVersions')
 
   const productResponse: Product = {
     ...mockProduct

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@kong-ui-public/spec-renderer": "0.13.5",
     "@kong/kong-auth-elements": "2.11.1",
     "@kong/kongponents": "8.127.0",
-    "@kong/sdk-portal-js": "2.6.1",
+    "@kong/sdk-portal-js": "2.7.0",
     "@xstate/vue": "2.0.0",
     "axios": "1.6.0",
     "date-fns": "3.3.0",

--- a/src/views/Spec.vue
+++ b/src/views/Spec.vue
@@ -112,7 +112,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref, watch, onMounted, toRaw, ComputedGetter } from 'vue'
+import { defineComponent, computed, ref, watch, onMounted, toRaw, ComputedGetter, PropType } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useRoute, useRouter } from 'vue-router'
 import jsyaml from 'js-yaml'
@@ -121,7 +121,7 @@ import getMessageFromError from '@/helpers/getMessageFromError'
 import ViewSpecModal from '@/components/ViewSpecModal.vue'
 import ViewSpecRegistrationModal from '@/components/ViewSpecRegistrationModal.vue'
 import usePortalApi from '@/hooks/usePortalApi'
-import { useI18nStore, useAppStore, usePermissionsStore, useProductStore } from '@/stores'
+import { useI18nStore, useAppStore, usePermissionsStore, useProductStore, ProductWithVersions } from '@/stores'
 import { OperationListItem, SpecDetails } from '@kong-ui-public/spec-renderer'
 import { idFromPathMethod } from '@/helpers/generatedOperationId'
 import '@kong-ui-public/spec-renderer/dist/style.css'
@@ -138,7 +138,7 @@ export default defineComponent({
   },
   props: {
     product: {
-      type: Object,
+      type: Object as PropType<ProductWithVersions>,
       required: true
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,10 +1119,10 @@
     v-calendar "3.0.0-alpha.8"
     vue-draggable-next "^2.2.1"
 
-"@kong/sdk-portal-js@2.6.1":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@kong/sdk-portal-js/-/sdk-portal-js-2.6.1.tgz#b855a505c0166825fcd4494f385a61bd7e5039e6"
-  integrity sha512-Q5Vcw57j48F+ujhGgtbTWyvshZBJgX/VKoZgEeRiJABAdfN7Td9CB+8UCAvK2uhk4kB0lzh/HCVqv9kCD1IhAQ==
+"@kong/sdk-portal-js@2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@kong/sdk-portal-js/-/sdk-portal-js-2.7.0.tgz#8bacc5d27ff4c6ad656c48c809598b1f8d976cce"
+  integrity sha512-KrbIqStnE/43eGmfZpwhrnZ5f1P0oAxw0Ot4YmcyH9J0J+icyIoZBfBMZLexkeUUkWzE3Hjd0UsNlJ/0sf1yhg==
   dependencies:
     axios "1.6.0"
 


### PR DESCRIPTION
This work is currently behind a feature flag. when enabled, the applications list in the product version view will only list those that match the auth_strategy_id of the product version.