### PR TITLE
feat(app-reg-v2): show auth strategy info in spec view (TDX-3718)

### DIFF
--- a/cypress/e2e/fixtures/consts.ts
+++ b/cypress/e2e/fixtures/consts.ts
@@ -11,6 +11,31 @@ const versions: ProductVersion[] = [
   }
 ]
 
+const versionWithOidcAuthStrategy: ProductVersion = {
+  ...versions[0],
+  registration_configs: [
+    {
+      auth_methods: ['bearer', 'client_credentials'],
+      name: 'oidc auth strategy',
+      credential_type: 'client_credentials'
+    }
+  ]
+}
+
+const versionWithKeyAuthAuthStrategy: ProductVersion = {
+  created_at: '2022-03-26T14:52:46.323Z',
+  updated_at: '2022-03-26T14:52:46.323Z',
+  id: '1afac832-5b2a-474c-a56d-c241364f41cf',
+  name: 'v1-beta',
+  deprecated: false,
+  registration_configs: [
+    {
+      name: 'key auth auth strategy',
+      credential_type: 'key_auth'
+    }
+  ]
+}
+
 const product: Product = {
   created_at: '2022-03-23T14:52:41.893Z',
   updated_at: '2022-03-23T14:52:41.893Z',
@@ -94,4 +119,4 @@ const productRegistrations: GetRegistrationResponse[] = [
   productRegistration
 ]
 
-export { versions, product, productVersion, productRegistration, productRegistrations, apps, defaultContext }
+export { versions, product, productVersion, productRegistration, versionWithOidcAuthStrategy, versionWithKeyAuthAuthStrategy, productRegistrations, apps, defaultContext }

--- a/cypress/e2e/specs/application_registration.spec.ts
+++ b/cypress/e2e/specs/application_registration.spec.ts
@@ -1,5 +1,5 @@
 import { CredentialCreationResponse, GetApplicationResponse, ListCredentialsResponse, ListCredentialsResponseDataInner, ListRegistrationsResponse } from '@kong/sdk-portal-js'
-import { product, versions, productRegistration, apps } from '../fixtures/consts'
+import { product, versions, productRegistration, apps, versionWithKeyAuthAuthStrategy, versionWithOidcAuthStrategy } from '../fixtures/consts'
 
 const mockApplicationWithCredAndReg = (
   data: GetApplicationResponse,
@@ -672,6 +672,83 @@ describe('Application Registration', () => {
         'contain',
         'You will be notified upon approval'
       )
+    })
+    it.only('appreg-v2 - feature flag off - does not show auth strategy card', () => {
+      cy.mockLaunchDarklyFlags([
+        {
+          name: 'tdx-3531-app-reg-v2',
+          value: false
+        }
+      ])
+      cy.mockProductDocument()
+      cy.mockProduct(product.id, product, [versionWithKeyAuthAuthStrategy])
+      cy.mockProductVersionApplicationRegistration(versions[0])
+      cy.mockGetProductDocuments(product.id)
+      cy.mockProductOperations(product.id, versions[0].id)
+      cy.mockProductVersionSpec(product.id, versions[0].id)
+      cy.mockRegistrations('*', []) // mock with empty so that we add one.
+
+      cy.viewport(1440, 900)
+      cy.visit(`/spec/${product.id}`)
+      cy.get('.swagger-ui', { timeout: 12000 }).should('exist')
+
+      cy.get('[data-testid="auth-strategy-card"]').should('not.exist')
+      cy.get('[data-testid="app-reg-v2-register-btn"]').should('not.exist')
+      cy.get('[data-testid="register-button"]', { timeout: 12000 }).should('exist')
+    })
+    it.only('appreg-v2 - feature flag on - shows information about application auth strategy (key-auth)', () => {
+      cy.mockLaunchDarklyFlags([
+        {
+          name: 'tdx-3531-app-reg-v2',
+          value: true
+        }
+      ])
+      cy.mockProductDocument()
+      cy.mockProduct(product.id, product, [versionWithKeyAuthAuthStrategy])
+      cy.mockProductVersionApplicationRegistration(versions[0])
+      cy.mockGetProductDocuments(product.id)
+      cy.mockProductOperations(product.id, versions[0].id)
+      cy.mockProductVersionSpec(product.id, versions[0].id)
+      cy.mockRegistrations('*', []) // mock with empty so that we add one.
+
+      cy.viewport(1440, 900)
+      cy.visit(`/spec/${product.id}`)
+      cy.get('.swagger-ui', { timeout: 12000 }).should('exist')
+
+      cy.get('[data-testid="auth-strategy-card"]').should('exist')
+      cy.get('[data-testid="auth-strategy-title"]').should('exist').should('contain.text', versionWithKeyAuthAuthStrategy.registration_configs[0].name)
+      cy.get('[data-testid="auth-method-key-auth"]').should('exist')
+      cy.get('[data-testid="app-reg-v2-bearer"]').should('not.exist')
+      cy.get('[data-testid="app-reg-v2-register-btn"]').should('exist')
+      cy.get('[data-testid="register-button"]', { timeout: 12000 }).should('not.exist')
+    })
+    it.only('appreg-v2 - feature flag on - shows information about application auth strategy (oidc auth)', () => {
+      cy.mockLaunchDarklyFlags([
+        {
+          name: 'tdx-3531-app-reg-v2',
+          value: true
+        }
+      ])
+      cy.mockProductDocument()
+      cy.mockProduct(product.id, product, [versionWithOidcAuthStrategy])
+      cy.mockProductVersionApplicationRegistration(versions[0])
+      cy.mockGetProductDocuments(product.id)
+      cy.mockProductOperations(product.id, versions[0].id)
+      cy.mockProductVersionSpec(product.id, versions[0].id)
+      cy.mockRegistrations('*', []) // mock with empty so that we add one.
+
+      cy.viewport(1440, 900)
+      cy.visit(`/spec/${product.id}`)
+      cy.get('.swagger-ui', { timeout: 12000 }).should('exist')
+
+      cy.get('[data-testid="auth-strategy-card"]').should('exist')
+      cy.get('[data-testid="auth-strategy-title"]').should('exist').should('contain.text', versionWithOidcAuthStrategy.registration_configs[0].name)
+      cy.get('[data-testid="auth-method-key-auth"]').should('not.exist')
+      versionWithOidcAuthStrategy.registration_configs[0].auth_methods.forEach((method) => {
+        cy.get(`[data-testid="auth-method-${method}"]`).should('exist')
+      })
+      cy.get('[data-testid="app-reg-v2-register-btn"]').should('exist')
+      cy.get('[data-testid="register-button"]', { timeout: 12000 }).should('not.exist')
     })
 
     it('does not show select available scopes if no scopes are available - feature flag on', () => {

--- a/cypress/e2e/specs/application_registration.spec.ts
+++ b/cypress/e2e/specs/application_registration.spec.ts
@@ -673,7 +673,7 @@ describe('Application Registration', () => {
         'You will be notified upon approval'
       )
     })
-    it.only('appreg-v2 - feature flag off - does not show auth strategy card', () => {
+    it('appreg-v2 - feature flag off - does not show auth strategy card', () => {
       cy.mockLaunchDarklyFlags([
         {
           name: 'tdx-3531-app-reg-v2',
@@ -696,7 +696,7 @@ describe('Application Registration', () => {
       cy.get('[data-testid="app-reg-v2-register-btn"]').should('not.exist')
       cy.get('[data-testid="register-button"]', { timeout: 12000 }).should('exist')
     })
-    it.only('appreg-v2 - feature flag on - shows information about application auth strategy (key-auth)', () => {
+    it('appreg-v2 - feature flag on - shows information about application auth strategy (key-auth)', () => {
       cy.mockLaunchDarklyFlags([
         {
           name: 'tdx-3531-app-reg-v2',
@@ -722,7 +722,7 @@ describe('Application Registration', () => {
       cy.get('[data-testid="app-reg-v2-register-btn"]').should('exist')
       cy.get('[data-testid="register-button"]', { timeout: 12000 }).should('not.exist')
     })
-    it.only('appreg-v2 - feature flag on - shows information about application auth strategy (oidc auth)', () => {
+    it('appreg-v2 - feature flag on - shows information about application auth strategy (oidc auth)', () => {
       cy.mockLaunchDarklyFlags([
         {
           name: 'tdx-3531-app-reg-v2',

--- a/src/components/ActionsDropdown.vue
+++ b/src/components/ActionsDropdown.vue
@@ -12,7 +12,7 @@
   >
     <slot>
       <KButton
-        apperance="btn-link"
+        appearance="btn-link"
         class="action-dropdown-button"
       >
         <KBadge

--- a/src/locales/ca_ES.ts
+++ b/src/locales/ca_ES.ts
@@ -44,6 +44,15 @@ export const ca_ES: I18nType = {
     noProductVersionsTitle: translationNeeded(en.productVersion.noProductVersionsTitle),
     registerProductVersion: translationNeeded(en.productVersion.registerProductVersion)
   },
+  authStrategyInfo: {
+    title: (authStrategyName: string) => translationNeeded(en.authStrategyInfo.title(authStrategyName)),
+    registerBtnText: (productVersionName: string) => translationNeeded(en.authStrategyInfo.registerBtnText(productVersionName)),
+    authMethods: translationNeeded(en.authStrategyInfo.authMethods),
+    bearer: translationNeeded(en.authStrategyInfo.bearer),
+    keyAuth: translationNeeded(en.authStrategyInfo.keyAuth),
+    clientCredentials: translationNeeded(en.authStrategyInfo.clientCredentials),
+    session: translationNeeded(en.authStrategyInfo.session)
+  },
   userDropdown: {
     myApps: 'Les meves aplicacions',
     logout: 'Tancar sessió'

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -44,6 +44,15 @@ export const de: I18nType = {
     noProductVersionsTitle: translationNeeded(en.productVersion.noProductVersionsTitle),
     registerProductVersion: translationNeeded(en.productVersion.registerProductVersion)
   },
+  authStrategyInfo: {
+    title: (authStrategyName: string) => translationNeeded(en.authStrategyInfo.title(authStrategyName)),
+    registerBtnText: (productVersionName: string) => translationNeeded(en.authStrategyInfo.registerBtnText(productVersionName)),
+    authMethods: translationNeeded(en.authStrategyInfo.authMethods),
+    bearer: translationNeeded(en.authStrategyInfo.bearer),
+    keyAuth: translationNeeded(en.authStrategyInfo.keyAuth),
+    clientCredentials: translationNeeded(en.authStrategyInfo.clientCredentials),
+    session: translationNeeded(en.authStrategyInfo.session)
+  },
   userDropdown: {
     myApps: 'Meine Applikationen',
     logout: 'Abmelden'

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -40,6 +40,15 @@ export const en = {
     noProductVersionsTitle: 'No Product Versions',
     registerProductVersion: 'Register Product version'
   },
+  authStrategyInfo: {
+    title: (authStrategyName: string) => `Supported Application Auth Strategy: ${authStrategyName}`,
+    registerBtnText: (productVersionName: string) => `Register for ${productVersionName}`,
+    authMethods: 'Auth Methods:',
+    bearer: 'Bearer',
+    keyAuth: 'Key Auth',
+    clientCredentials: 'Client Credentials',
+    session: 'Session'
+  },
   userDropdown: {
     myApps: 'My Apps',
     logout: 'Logout'

--- a/src/locales/es_ES.ts
+++ b/src/locales/es_ES.ts
@@ -44,6 +44,15 @@ export const es_ES: I18nType = {
     noProductVersionsTitle: translationNeeded(en.productVersion.noProductVersionsTitle),
     registerProductVersion: translationNeeded(en.productVersion.registerProductVersion)
   },
+  authStrategyInfo: {
+    title: (authStrategyName: string) => translationNeeded(en.authStrategyInfo.title(authStrategyName)),
+    registerBtnText: (productVersionName: string) => translationNeeded(en.authStrategyInfo.registerBtnText(productVersionName)),
+    authMethods: translationNeeded(en.authStrategyInfo.authMethods),
+    bearer: translationNeeded(en.authStrategyInfo.bearer),
+    keyAuth: translationNeeded(en.authStrategyInfo.keyAuth),
+    clientCredentials: translationNeeded(en.authStrategyInfo.clientCredentials),
+    session: translationNeeded(en.authStrategyInfo.session)
+  },
   userDropdown: {
     myApps: 'Mis aplicaciones',
     logout: 'Cerrar sesión'

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -44,6 +44,15 @@ export const fr: I18nType = {
     noProductVersionsTitle: 'Aucune version de produit',
     registerProductVersion: 'Enregistrer une version de produit'
   },
+  authStrategyInfo: {
+    title: (authStrategyName: string) => translationNeeded(en.authStrategyInfo.title(authStrategyName)),
+    registerBtnText: (productVersionName: string) => translationNeeded(en.authStrategyInfo.registerBtnText(productVersionName)),
+    authMethods: translationNeeded(en.authStrategyInfo.authMethods),
+    bearer: translationNeeded(en.authStrategyInfo.bearer),
+    keyAuth: translationNeeded(en.authStrategyInfo.keyAuth),
+    clientCredentials: translationNeeded(en.authStrategyInfo.clientCredentials),
+    session: translationNeeded(en.authStrategyInfo.session)
+  },
   userDropdown: {
     myApps: 'Mes Applications',
     logout: 'Déconnexion'

--- a/src/locales/i18n-type.d.ts
+++ b/src/locales/i18n-type.d.ts
@@ -40,6 +40,15 @@ export interface I18nType {
     noProductVersionsTitle: string;
     registerProductVersion: string;
   };
+  authStrategyInfo: {
+    title: (authStrategyName: string) => string;
+    registerBtnText: (productVersionName: string) => string;
+    authMethods: string;
+    bearer: string;
+    keyAuth: string;
+    clientCredentials: string;
+    session: string;
+  };
   userDropdown: {
     myApps: string;
     logout: string;


### PR DESCRIPTION
Shows information about the auth strategy if it's present for v2
<img width="978" alt="Screenshot 2024-02-02 at 1 00 18 PM" src="https://github.com/Kong/konnect-portal/assets/40131297/7559a0b8-9694-4737-b0c0-ca7cb476dde9">
