### PR TITLE
fix: add loading logic for auth strategies fetch

### DIFF
--- a/src/views/Applications/ApplicationForm.vue
+++ b/src/views/Applications/ApplicationForm.vue
@@ -16,7 +16,7 @@
           <span class="text-danger">*</span> {{ helpText.application.reqField }}
         </p>
         <KAlert
-          v-if="appRegV2Enabled && !hasAppAuthStrategies && formMode === 'create'"
+          v-if="appRegV2Enabled && !hasAppAuthStrategies && !fetchingAuthStrategies && formMode === 'create'"
           :alert-message="helpText.application.authStrategyWarning"
           appearance="warning"
           class="no-auth-strategies-warning"
@@ -249,6 +249,7 @@ export default defineComponent({
     const secretModalIsVisible = ref(false)
     const appRegV2Enabled = useLDFeatureFlag(FeatureFlags.AppRegV2, false)
     const hasAppAuthStrategies = ref(false)
+    const fetchingAuthStrategies = ref(true)
 
     const defaultFormData: UpdateApplicationPayload = makeDefaultFormData(isDcr.value)
     const formData = ref(defaultFormData)
@@ -309,12 +310,17 @@ export default defineComponent({
       }
 
       if (appRegV2Enabled) {
+        fetchingAuthStrategies.value = true
+
         try {
           const appAuthStrategies = await portalApiV2.value.service.applicationsApi.listApplicationAuthStrategies()
           if (appAuthStrategies.data?.data?.length) {
             hasAppAuthStrategies.value = true
           }
+
+          fetchingAuthStrategies.value = false
         } catch (err) {
+          fetchingAuthStrategies.value = false
           notify({
             appearance: 'danger',
             message: `Error fetching application auth strategies: ${err}`
@@ -483,6 +489,7 @@ export default defineComponent({
       clientSecret,
       clientId,
       copyTokenToClipboard,
+      fetchingAuthStrategies,
       secretModalIsVisible,
       handleAcknowledgeSecret,
       hasAppAuthStrategies,

--- a/src/views/MyApps.vue
+++ b/src/views/MyApps.vue
@@ -33,7 +33,7 @@
       </template>
     </PageTitle>
     <KAlert
-      v-if="appRegV2Enabled && !hasAppAuthStrategies"
+      v-if="appRegV2Enabled && !hasAppAuthStrategies && !fetchingAuthStrategies"
       :alert-message="helpText.authStrategyWarning"
       appearance="warning"
       class="no-auth-strategies-warning"
@@ -233,6 +233,7 @@ export default defineComponent({
     const { portalApiV2 } = usePortalApi()
     const appRegV2Enabled = useLDFeatureFlag(FeatureFlags.AppRegV2, false)
     const hasAppAuthStrategies = ref(false)
+    const fetchingAuthStrategies = ref(true)
 
     const appStore = useAppStore()
     const { isDcr } = storeToRefs(appStore)
@@ -368,12 +369,16 @@ export default defineComponent({
       vitalsLoading.value = false
 
       if (appRegV2Enabled) {
+        fetchingAuthStrategies.value = true
         try {
           const appAuthStrategies = await portalApiV2.value.service.applicationsApi.listApplicationAuthStrategies()
           if (appAuthStrategies.data?.data?.length) {
             hasAppAuthStrategies.value = true
           }
+
+          fetchingAuthStrategies.value = false
         } catch (err) {
+          fetchingAuthStrategies.value = false
           notify({
             appearance: 'danger',
             message: `Error fetching application auth strategies: ${err}`
@@ -389,6 +394,7 @@ export default defineComponent({
       currentState,
       tableHeaders,
       handleDelete,
+      fetchingAuthStrategies,
       isDcr,
       deleteItem,
       showSecretModal,


### PR DESCRIPTION
Adds loading logic so that the alert message does not display before the auth strategies have been fetched.