### PR TITLE
fix(product): ensure product and version are available before rendering dependent components

### DIFF
--- a/src/components/ViewSpecRegistrationModal.vue
+++ b/src/components/ViewSpecRegistrationModal.vue
@@ -241,7 +241,7 @@ export default defineComponent({
 
     const authStrategyId = computed(() => {
       const productVersion = $route.params.product_version
-      const matchingVersion = props.product.versions.find((version) => version.id === productVersion)
+      const matchingVersion = props.product?.versions?.find((version) => version.id === productVersion)
       if (!matchingVersion) {
         return
       }

--- a/src/components/product/Sidebar.vue
+++ b/src/components/product/Sidebar.vue
@@ -30,6 +30,7 @@
       </header>
       <SectionOverview :product="product" />
       <SectionReference
+        v-if="activeProductVersionId"
         :active-product-version-id="activeProductVersionId"
         :product="product"
         :deselect-operation="deselectOperation"

--- a/src/views/ProductShell.vue
+++ b/src/views/ProductShell.vue
@@ -6,7 +6,7 @@
       class="mt-6"
       :message="productError"
     />
-    <template v-else>
+    <template v-else-if="product">
       <div
         class="sidebar-wrapper"
       >


### PR DESCRIPTION
This PR resolves an error with the App Reg modal when redirecting back from the create application page. In addition, it adds guards to not renderer components that rely on the product and version until they have been fetched. 