### PR TITLE
feat(app-reg-v2): autoselect strategy from modal if param is present

### DIFF
--- a/src/components/ViewSpecRegistrationModal.vue
+++ b/src/components/ViewSpecRegistrationModal.vue
@@ -254,7 +254,7 @@ export default defineComponent({
         product: $route.params.product,
         product_version: $route.params.product_version,
         ...(useAppRegV2 && authStrategyId.value)
-          ? { 'auth-strategy-id': authStrategyId.value }
+          ? { auth_strategy_id: authStrategyId.value }
           : {}
       }
     })

--- a/src/views/Applications/ApplicationForm.vue
+++ b/src/views/Applications/ApplicationForm.vue
@@ -472,7 +472,7 @@ export default defineComponent({
             description: res.data.description || '',
             redirect_uri: res.data.redirect_uri,
             reference_id: res.data.reference_id,
-            auth_strategy_id: res.data.auth_strategy_id
+            auth_strategy_id: res.data.auth_strategy?.id
           }
           if (isDcr.value) {
             delete newFormData.reference_id


### PR DESCRIPTION
The param that is referenced needed to be updated, and we are now using an `auth_strategy.id` instead.