### PR TITLE
adding java and c# to the swagger languages

### DIFF
--- a/src/views/Spec.vue
+++ b/src/views/Spec.vue
@@ -90,6 +90,36 @@
       :application-registration-enabled="appRegV2Enabled ? false : applicationRegistrationEnabled"
       :active-operation="sidebarActiveOperationListItem"
       :current-version="currentVersion?.name"
+      :theme-overrides="{
+        languages: [
+          {
+            prismLanguage: 'bash',
+            target: 'shell',
+            client: 'curl'
+          },
+          {
+            prismLanguage: 'javascript',
+            target: 'javascript',
+            client: 'xhr'
+          },
+          {
+            prismLanguage: 'python',
+            target: 'python'
+          },
+          {
+            prismLanguage: 'ruby',
+            target: 'ruby'
+          },
+          {
+            prismLanguage: 'java',
+            target: 'java'
+          },
+          {
+            prismLanguage: 'csharp',
+            target: 'csharp'
+          }
+        ]
+      }"
       @clicked-view-spec="triggerViewSpecModal"
       @clicked-register="triggerViewSpecRegistrationModal"
     />


### PR DESCRIPTION
As many developers use java and C# for testing their specs, requesting to add these 2 languages to the tryitout button 