### PR TITLE
fix: check strategy matches selected value in form

### DIFF
--- a/src/components/ViewSpecRegistrationModal.vue
+++ b/src/components/ViewSpecRegistrationModal.vue
@@ -25,6 +25,7 @@
           class="alert-message"
         />
         <KTable
+          class="applications-list"
           :is-loading="currentState.matches('pending')"
           data-testid="applications-list"
           :fetcher-cache-key="fetcherCacheKey"
@@ -369,7 +370,7 @@ export default defineComponent({
 
     watch(() => selectedApplication.value, (newSelectedApplication, oldSelectedApplication) => {
       // We reset selectedScopes if we change applications
-      if (newSelectedApplication !== oldSelectedApplication && selectedScopes.value.length) {
+      if (newSelectedApplication !== oldSelectedApplication && selectedScopes.value?.length) {
         selectedScopes.value = []
       }
     })
@@ -455,12 +456,11 @@ export default defineComponent({
 
  .table-text {
   text-align: left;
-  font-weight: 600;
  }
 
  .application-registration-modal {
   :deep(.selected) {
-    .k-input-label {
+    td {
       font-weight: 600;
       width: 100%;
     }

--- a/src/views/Applications/ApplicationForm.vue
+++ b/src/views/Applications/ApplicationForm.vue
@@ -355,7 +355,7 @@ export default defineComponent({
               value: strat.id,
               isDcr: strat.credential_type === 'client_credentials',
               isSelfManaged: strat.credential_type === 'self_managed_client_credentials',
-              selected: formData.value.auth_strategy_id ? strat.id === formData.value.auth_strategy_id : ($route.query.auth_strategy_id || false)
+              selected: formData.value.auth_strategy_id ? strat.id === formData.value.auth_strategy_id : (strat.id === $route.query.auth_strategy_id || false)
             }))
           }
 


### PR DESCRIPTION
The logic was not checking if the value was equal to the `strat.id` before, added that in and fixed the styling with the font weight to make it more visible that an item is selected.