### PR TITLE
chore: update to latest portal sdk

### DIFF
--- a/cypress/e2e/fixtures/consts.ts
+++ b/cypress/e2e/fixtures/consts.ts
@@ -136,6 +136,7 @@ export const appWithAuthStrategy: GetApplicationResponse = {
   auth_strategy: {
     id: crypto.randomUUID(),
     name: 'keyauthstrat',
+    key_names: ['key'],
     credential_type: AuthStrategyKeyAuthCredentialTypeEnum.KeyAuth
   }
 }

--- a/cypress/e2e/specs/application_registration.spec.ts
+++ b/cypress/e2e/specs/application_registration.spec.ts
@@ -1,4 +1,4 @@
-import { AuthStrategyClientCredentialsCredentialTypeEnum, AuthStrategyKeyAuthCredentialTypeEnum, CredentialCreationResponse, GetApplicationResponse, PortalAuthStrategy, ListCredentialsResponse, ListCredentialsResponseDataInner, ListRegistrationsResponse } from '@kong/sdk-portal-js'
+import { AuthStrategyClientCredentialsCredentialTypeEnum, AuthStrategyKeyAuthCredentialTypeEnum, CredentialCreationResponse, GetApplicationResponse, ListCredentialsResponse, ListCredentialsResponseDataInner, ListRegistrationsResponse } from '@kong/sdk-portal-js'
 import { product, versions, productRegistration, apps, productWithKeyAuthAppAuthStrategy, appWithAuthStrategy, versionWithKeyAuthAuthStrategy, versionWithOidcAuthStrategy } from '../fixtures/consts'
 
 const mockApplicationWithCredAndReg = (
@@ -187,7 +187,7 @@ describe('Application Registration', () => {
         }
       ])
       cy.mockApplications([], 0)
-      cy.mockApplicationAuthStrategies([{ name: 'foo', id: '1', credential_type: 'client_credentials' } as PortalAuthStrategy], 0)
+      cy.mockApplicationAuthStrategies([{ name: 'foo', id: '1', credential_type: 'client_credentials', auth_methods: ['session', 'bearer'] }], 0)
 
       cy.mockDcrPortal()
       cy.visit('/my-apps')

--- a/cypress/e2e/specs/application_registration.spec.ts
+++ b/cypress/e2e/specs/application_registration.spec.ts
@@ -1,4 +1,4 @@
-import { AuthStrategyClientCredentialsCredentialTypeEnum, AuthStrategyKeyAuthCredentialTypeEnum, CredentialCreationResponse, GetApplicationResponse, ListAuthStrategiesItem, ListCredentialsResponse, ListCredentialsResponseDataInner, ListRegistrationsResponse } from '@kong/sdk-portal-js'
+import { AuthStrategyClientCredentialsCredentialTypeEnum, AuthStrategyKeyAuthCredentialTypeEnum, CredentialCreationResponse, GetApplicationResponse, PortalAuthStrategy, ListCredentialsResponse, ListCredentialsResponseDataInner, ListRegistrationsResponse } from '@kong/sdk-portal-js'
 import { product, versions, productRegistration, apps, productWithKeyAuthAppAuthStrategy, appWithAuthStrategy, versionWithKeyAuthAuthStrategy, versionWithOidcAuthStrategy } from '../fixtures/consts'
 
 const mockApplicationWithCredAndReg = (
@@ -187,7 +187,7 @@ describe('Application Registration', () => {
         }
       ])
       cy.mockApplications([], 0)
-      cy.mockApplicationAuthStrategies([{ name: 'foo', id: '1', credential_type: 'client_credentials' } as ListAuthStrategiesItem], 0)
+      cy.mockApplicationAuthStrategies([{ name: 'foo', id: '1', credential_type: 'client_credentials' } as PortalAuthStrategy], 0)
 
       cy.mockDcrPortal()
       cy.visit('/my-apps')
@@ -235,7 +235,7 @@ describe('Application Registration', () => {
         }
       ])
       cy.mockApplications([], 0)
-      cy.mockApplicationAuthStrategies([{ name: 'foo', id: '1', credential_type: 'key_auth' } as ListAuthStrategiesItem], 0)
+      cy.mockApplicationAuthStrategies([{ name: 'foo', id: '1', credential_type: 'key_auth', key_names: ['key1', 'key2'] }], 0)
 
       cy.mockDcrPortal()
       cy.visit('/my-apps')
@@ -280,10 +280,10 @@ describe('Application Registration', () => {
       ])
       cy.mockApplications([], 0)
       cy.mockApplicationAuthStrategies([
-        { name: 'foo', id: '1', credential_type: 'client_credentials' },
-        { name: 'bar', id: '2', credential_type: 'key_auth' },
-        { name: 'baz', id: '3', credential_type: 'self_managed_client_credentials' }
-      ] as ListAuthStrategiesItem[], 0)
+        { name: 'foo', id: '1', credential_type: 'client_credentials', auth_methods: ['client_credentials', 'session'] },
+        { name: 'bar', id: '2', credential_type: 'key_auth', key_names: ['key1', 'key2'] },
+        { name: 'baz', id: '3', credential_type: 'self_managed_client_credentials', auth_methods: ['client_credentials', 'session', 'bearer'] }
+      ], 0)
 
       cy.mockDcrPortal()
       cy.visit('/my-apps')
@@ -1237,7 +1237,8 @@ describe('Application Registration', () => {
       auth_strategy: {
         id: 'key-auth-strat-id',
         name: 'keyauthstrat',
-        credential_type: AuthStrategyKeyAuthCredentialTypeEnum.KeyAuth
+        credential_type: AuthStrategyKeyAuthCredentialTypeEnum.KeyAuth,
+        key_names: ['key1', 'key2']
       }
     }
 

--- a/cypress/e2e/support/index.ts
+++ b/cypress/e2e/support/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 // Import commands.js using ES2015 syntax:
-import { GetApplicationResponse, GetRegistrationResponse, ListAuthStrategiesItem, ListCredentialsResponseDataInner, PortalAppearance, PortalContext, Product, ProductCatalogIndexSource, ProductVersion, ProductVersionSpecOperationsOperationsInner } from '@kong/sdk-portal-js'
+import { GetApplicationResponse, GetRegistrationResponse, PortalAuthStrategy, ListCredentialsResponseDataInner, PortalAppearance, PortalContext, Product, ProductCatalogIndexSource, ProductVersion, ProductVersionSpecOperationsOperationsInner } from '@kong/sdk-portal-js'
 import './mock-commands'
 import { SinonStub } from 'cypress/types/sinon'
 
@@ -26,7 +26,7 @@ declare global {
       mockProduct(productId?: string, mockProduct?: Product, mockVersions?: ProductVersion[]): Chainable<JQuery<HTMLElement>>
       mockProductVersion(productId?: string, versionId?: string, mockVersion?: ProductVersion): Chainable<JQuery<HTMLElement>>
       mockApplications(searchResults?: Array<GetApplicationResponse>, totalCount?: number, pageSize?: number, pageNumber?: number): Chainable<JQuery<HTMLElement>>
-      mockApplicationAuthStrategies(authStrategyItems?: Array<ListAuthStrategiesItem>, totalCount?: number, pageSize?: number, pageNumber?: number): Chainable<JQuery<HTMLElement>>
+      mockApplicationAuthStrategies(authStrategyItems?: Array<PortalAuthStrategy>, totalCount?: number, pageSize?: number, pageNumber?: number): Chainable<JQuery<HTMLElement>>
       mockApplicationWithCredAndReg(data: GetApplicationResponse, credentials?: ListCredentialsResponseDataInner[], registrations?: Array<GetRegistrationResponse>): Chainable<JQuery<HTMLElement>>,
       mockContextualAnalytics(): Chainable<JQuery<HTMLElement>>
       mockRegistrations(applicationId?: string, registrations?: Array<GetRegistrationResponse>, totalCount?: number): Chainable<JQuery<HTMLElement>>

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@kong-ui-public/spec-renderer": "0.13.5",
     "@kong/kong-auth-elements": "2.11.1",
     "@kong/kongponents": "8.127.0",
-    "@kong/sdk-portal-js": "2.8.0",
+    "@kong/sdk-portal-js": "2.9.0",
     "@xstate/vue": "2.0.0",
     "axios": "1.6.0",
     "date-fns": "3.3.0",

--- a/src/views/Applications/ApplicationDetail.vue
+++ b/src/views/Applications/ApplicationDetail.vue
@@ -188,7 +188,7 @@ import {
 } from '@kong-ui-public/analytics-utilities'
 import { FeatureFlags } from '@/constants/feature-flags'
 import useLDFeatureFlag from '@/hooks/useLDFeatureFlag'
-import { AuthStrategyCredentialType } from '@kong/sdk-portal-js'
+import { CredentialType } from '@kong/sdk-portal-js'
 
 export default defineComponent({
   name: 'ApplicationDetail',
@@ -236,13 +236,13 @@ export default defineComponent({
     }))
 
     const isApplicationOIDC = computed(() => {
-      return application.value.auth_strategy?.credential_type === AuthStrategyCredentialType.SelfManagedClientCredentials
+      return application.value.auth_strategy?.credential_type === CredentialType.SelfManagedClientCredentials
     })
 
     const isApplicationDcr = computed(() => {
       if (appRegV2Enabled && application.value) {
         // check the application type
-        if (application.value.auth_strategy?.credential_type === AuthStrategyCredentialType.ClientCredentials) {
+        if (application.value.auth_strategy?.credential_type === CredentialType.ClientCredentials) {
           return true
         } else {
           return false

--- a/src/views/Applications/ApplicationForm.vue
+++ b/src/views/Applications/ApplicationForm.vue
@@ -232,7 +232,7 @@ import usePortalApi from '@/hooks/usePortalApi'
 import cleanupEmptyFields from '@/helpers/cleanupEmptyFields'
 import useToaster from '@/composables/useToaster'
 import { useI18nStore, useAppStore } from '@/stores'
-import { CreateApplicationPayload, ListAuthStrategiesItem } from '@kong/sdk-portal-js'
+import { CreateApplicationPayload, PortalAuthStrategy } from '@kong/sdk-portal-js'
 import { FeatureFlags } from '@/constants/feature-flags'
 import useLDFeatureFlag from '@/hooks/useLDFeatureFlag'
 import { fetchAll } from '@/helpers/fetchAll'
@@ -350,7 +350,7 @@ export default defineComponent({
           const [_, rawAuthStrategies] = await Promise.all(promises)
           if (rawAuthStrategies.length) {
             hasAppAuthStrategies.value = true
-            appAuthStrategies.value = rawAuthStrategies.map((strat: ListAuthStrategiesItem) => ({
+            appAuthStrategies.value = rawAuthStrategies.map((strat: PortalAuthStrategy) => ({
               label: strat.name,
               value: strat.id,
               isDcr: strat.credential_type === 'client_credentials',

--- a/src/views/MyApps.vue
+++ b/src/views/MyApps.vue
@@ -215,7 +215,7 @@ import { EXPLORE_V2_DIMENSIONS, EXPLORE_V2_FILTER_TYPES, MetricsConsumer } from 
 import { storeToRefs } from 'pinia'
 import { FeatureFlags } from '@/constants/feature-flags'
 import useLDFeatureFlag from '@/hooks/useLDFeatureFlag'
-import { GetApplicationResponse, AuthStrategyCredentialType } from '@kong/sdk-portal-js'
+import { GetApplicationResponse, CredentialType } from '@kong/sdk-portal-js'
 
 export default defineComponent({
   name: 'MyApps',
@@ -249,7 +249,7 @@ export default defineComponent({
 
     const isApplicationDcr = (application: GetApplicationResponse) => {
       if (appRegV2Enabled) {
-        return application.auth_strategy?.credential_type === AuthStrategyCredentialType.ClientCredentials
+        return application.auth_strategy?.credential_type === CredentialType.ClientCredentials
       }
 
       return isPortalDcr.value

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,10 +1119,10 @@
     v-calendar "3.0.0-alpha.8"
     vue-draggable-next "^2.2.1"
 
-"@kong/sdk-portal-js@2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@kong/sdk-portal-js/-/sdk-portal-js-2.8.0.tgz#38046c8fa3fd48defa2c3d516ae2deebe925a5dd"
-  integrity sha512-inSNL+aCA8GHJUPyztjxX5a3WweAdjEH2+4f9okM6qhxvs1J0+eKJV+PDpttpb8FX47BZNqmq2W096KgJYqMAQ==
+"@kong/sdk-portal-js@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@kong/sdk-portal-js/-/sdk-portal-js-2.9.0.tgz#f35a728955f33b049861ea1c2bd5e5de515c82f3"
+  integrity sha512-NHuzKRyLEYebnN0nu+TUCHhewTENBEObOOUIF6GDDdEhgsAQMKOGcpbJoDf5wjKnp87sXWbBK02WEaVS8vt6Vw==
   dependencies:
     axios "1.6.0"
 


### PR DESCRIPTION
The SDK should no longer have any more `internal` flags, so this updates to the latest version of the SDK.