### PR TITLE
fix(products): unset product when unmounting shell

### DIFF
--- a/src/views/ProductShell.vue
+++ b/src/views/ProductShell.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, ref, watch, watchEffect } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch, watchEffect } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import getMessageFromError from '@/helpers/getMessageFromError'
@@ -211,6 +211,10 @@ onMounted(async () => {
   await fetchProduct()
   await fetchDocumentTree()
   initActiveProductVersionId()
+})
+
+onUnmounted(() => {
+  productStore.setProduct(null)
 })
 
 watch(() => productVersionParam.value, () => {


### PR DESCRIPTION
I believe this should fix the root of some testing flakiness. When we leave a product page and unmount the product shell, we will unset the product so that we do not have any stale state going between products.