### PR TITLE
ci: revert group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,6 @@ updates:
       prefix: chore(deps)
     labels:
       - "dependencies"
-    grouped-dependencies:
-      update-types:
-        - "minor"
-        - "patch"
     ignore:
       - dependency-name: "@kong-ui-public/analytics-chart"
       - dependency-name: "@kong-ui-public/analytics-metric-provider"


### PR DESCRIPTION
This reverts commit 71dcf09ee0eb51b63c3ccb6b0c41a77a93a9ec57.

There was a [schema complaint](https://github.com/Kong/konnect-portal/runs/22309197813) in CI on merge:
```
The property '#/updates/0/' contains additional properties ["grouped-dependencies"] outside of the schema when none are allowed
```