### PR TITLE
fix: hide auth strategy if public

### DIFF
--- a/cypress/e2e/specs/spec_renderer.spec.ts
+++ b/cypress/e2e/specs/spec_renderer.spec.ts
@@ -391,7 +391,7 @@ describe('Spec Renderer Page', () => {
       cy.visit(`/spec/${product.id}`)
 
       cy.get('[data-testid="kong-public-ui-spec-details-swagger"]', { timeout: 12000 })
-      .get('.info h2').should('contain', 'Swagger Petstore')
+        .get('.info h2').should('contain', 'Swagger Petstore')
 
       cy.get('[data-testid="register-button"]').should('exist')
 
@@ -426,6 +426,25 @@ describe('Spec Renderer Page', () => {
         .get('.info h2').should('contain', 'Swagger Petstore')
 
       cy.get('@apiNotCalled').should('not.been.called')
+    })
+    it.only('appregv2 - does not show auth strategy information if public portal', () => {
+      cy.mockLaunchDarklyFlags([
+        {
+          name: 'tdx-3531-app-reg-v2',
+          value: true
+        }
+      ])
+
+      cy.intercept('GET', '**/portal_api/portal/portal_context', {
+        rbac_enabled: true
+      }).as('getPortalContext')
+
+      cy.visit(`/spec/${product.id}`)
+
+      cy.get('[data-testid="kong-public-ui-spec-details-swagger"]', { timeout: 12000 })
+        .get('.info h2').should('contain', 'Swagger Petstore')
+
+      cy.get('[data-testid="auth-strategy-card"]', { timeout: 1000 }).should('not.exist')
     })
   })
 })

--- a/src/views/Spec.vue
+++ b/src/views/Spec.vue
@@ -6,7 +6,7 @@
     <div class="container max-w-screen-2xl px-5 md:px-0">
       <div class="swagger-ui has-sidebar breadcrumbs">
         <KCard
-          v-if="appRegV2Enabled && applicationRegistrationEnabled && currentVersion?.registration_configs?.length"
+          v-if="appRegV2Enabled && applicationRegistrationEnabled && currentVersion?.registration_configs?.length && !isPublic"
           class="auth-strategy-card"
           data-testid="auth-strategy-card"
         >


### PR DESCRIPTION
This information should not be visible if the portal is public.