### PR TITLE
chore: show auth strategy dropdown even if 1 auth strategy

### DIFF
--- a/src/views/Applications/ApplicationForm.vue
+++ b/src/views/Applications/ApplicationForm.vue
@@ -36,7 +36,6 @@
             />
           </div>
           <div
-            v-if="appAuthStrategies.length > 1"
             class="mb-5"
           >
             <KLabel


### PR DESCRIPTION
Show the auth strategy dropdown even if there is only one active auth strategy so that it is less confusing to the user.