### PR TITLE
fix(appreg): add KSkeleton to app reg modal header-content while state is pending

### DIFF
--- a/src/components/ViewSpecRegistrationModal.vue
+++ b/src/components/ViewSpecRegistrationModal.vue
@@ -8,7 +8,14 @@
     @canceled="closeModal"
   >
     <template #header-content>
-      <span class="color-text_colors-primary">
+      <KSkeleton
+        v-if="currentState.matches('pending')"
+        :delay-milliseconds="200"
+      />
+      <span
+        v-else
+        class="color-text_colors-primary"
+      >
         {{ applications.length ? modalText.title : helpText.applicationRegistration.noApplications }}
       </span>
     </template>


### PR DESCRIPTION
This PR adds a KSkeleton to the app reg modal header-content while the state is still pending.