### PR TITLE
fix(spec): handle case where operation has no tags

### DIFF
--- a/src/views/Spec.vue
+++ b/src/views/Spec.vue
@@ -215,7 +215,7 @@ export default defineComponent({
     const convertOperationToListItem: ComputedGetter<OperationListItem|null> = () => {
       if (sidebarActiveOperation.value) {
         const { tags, ...props } = sidebarActiveOperation.value
-        const tag = props.tag ? props.tag : tags[0]
+        const tag = props.tag ? props.tag : tags?.[0]
 
         return {
           ...props,


### PR DESCRIPTION
This PR adds optional chaining on the tags array reference to prevent an uncaught error when selecting operations in the "Default" section of the sidebar. This error causes the "scroll to operation" behavior to stop working

<img width="320" alt="image" src="https://github.com/Kong/konnect-portal/assets/5304468/bd84b660-6d20-4edd-9f2a-fc52e50bf2a8">

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading '0')
```