### PR TITLE
fix(markdown): add styling to li paragraphs

### DIFF
--- a/src/views/ApiDocumentationPage.vue
+++ b/src/views/ApiDocumentationPage.vue
@@ -232,6 +232,11 @@ export default defineComponent({
   pre {
     overflow-x: auto;
   }
+
+  li > p {
+    display: block;
+    margin-bottom: 12px;
+  }
 }
 </style>
 


### PR DESCRIPTION
Applies block and margin to list item paragraphs in markdown documents

