### PR TITLE
fix: login redirect was not handling hash

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHistory, RouteLocationNormalized } from 'vue-router'
 import { storeToRefs } from 'pinia'
 
 import { session } from '@/services'
@@ -224,7 +224,9 @@ export const portalRouter = () => {
         previousRoute: session.data?.to
       })
     ) {
-      return next(getRedirectRouteBasedOnPath(session.data.to, from.fullPath))
+      const redirectRoute = getRedirectRouteBasedOnPath(session.data.to, from.fullPath)
+
+      return next(redirectRoute)
     }
 
     if (shouldRedirectToLogin({ isPublic: isPublic.value, isSessionInvalid: !sessionDoesExist, to })) {
@@ -258,14 +260,23 @@ export function shouldRedirectUserToPreviouslyAccessedRoute ({
   isPublic,
   to,
   previousRoute
+}: {
+  isPublic: boolean
+  to: RouteLocationNormalized
+  previousRoute: string
 }) {
   const urlSearchParams = window && new URL(window.location.href)?.searchParams
 
+  const isLoginSuccessful = urlSearchParams?.get('loginSuccess') === 'true'
+  const hasPreviousRoute = previousRoute !== undefined
+  const isNewRoute = to.fullPath !== previousRoute
+  const isNotAuthRoute = !isAuthRoute(to.name)
+
   return (
     !isPublic &&
-    urlSearchParams?.get('loginSuccess') === 'true' &&
-    previousRoute !== undefined &&
-    to.fullPath !== previousRoute &&
-    !isAuthRoute(to.name)
+    isLoginSuccessful &&
+    hasPreviousRoute &&
+    isNewRoute &&
+    isNotAuthRoute
   )
 }

--- a/src/router/route-utils.ts
+++ b/src/router/route-utils.ts
@@ -1,5 +1,6 @@
 import useLDFeatureFlag from '@/hooks/useLDFeatureFlag'
 import { ProductAction, usePermissionsStore } from '@/stores'
+import { RouteLocationNormalized, RouteLocationRaw } from 'vue-router'
 
 export const AUTH_ROUTES = {
   login: true,
@@ -47,8 +48,17 @@ export function getRedirectRoute (redirectName, fromName) {
   return redirectName !== fromName && { name: redirectName }
 }
 
-export function getRedirectRouteBasedOnPath (redirectToPath, fromPath) {
-  return redirectToPath !== fromPath && { path: redirectToPath }
+export function getRedirectRouteBasedOnPath (redirectToPath: string, fromPath: string): RouteLocationRaw | undefined {
+  if (redirectToPath !== fromPath) {
+    const hash = redirectToPath.split('#')[1]
+
+    return {
+      path: redirectToPath,
+      hash: hash ? `#${hash}` : undefined
+    }
+  } else {
+    return undefined
+  }
 }
 
 export function removeQueryParam (queryParam) {
@@ -106,6 +116,6 @@ export function verifyDeveloperFulfillMetaForRoute (to) {
 
 // Combine both checks and should be used as default one to check developer permissions
 
-export async function shouldDeveloperAccessRoute (to, data) {
+export async function shouldDeveloperAccessRoute (to: RouteLocationNormalized, data: { portalId: string; }) {
   return verifyDeveloperFulfillMetaForRoute(to) && await verifyDeveloperIsAuthorizedForRoute(to, data)
 }


### PR DESCRIPTION
When passing a route to the `next` callback with an object that looks like `{path: string}`, the hash is not included. When the hash is included in the redirect, then, it would continually compare the path to the redirectPath, and they would not match (one would be missing the hash). Therefore it would cause an infinite redirect loop causing a crash/OOM.

By checking for a hash and passing it along to the `next` callback, it allows correct comparison, and redirects properly.