### PR TITLE
feat(auth): read saml auth enabled flag from portal context

### DIFF
--- a/cypress/e2e/specs/login.spec.ts
+++ b/cypress/e2e/specs/login.spec.ts
@@ -216,7 +216,7 @@ describe('Login Page', () => {
   })
 
   it('shows Login with SSO button', () => {
-    cy.mockPrivatePortal({ oidc_auth_enabled: true, basic_auth_enabled: false })
+    cy.mockPrivatePortal({ oidc_auth_enabled: true, basic_auth_enabled: false, saml_auth_enabled: false })
 
     cy.visit('/', { useOriginalFn: true })
     cy.location('pathname').should('equal', '/login')
@@ -225,8 +225,19 @@ describe('Login Page', () => {
     cy.get('[data-testid="kong-auth-login-sso"]').should('exist')
   })
 
+  it('shows Login with SSO button (SAML)', () => {
+    cy.mockPrivatePortal({ oidc_auth_enabled: false, basic_auth_enabled: false, saml_auth_enabled: true })
+
+    cy.visit('/', { useOriginalFn: true })
+    cy.location('pathname').should('equal', '/login')
+    cy.get('[data-testid="auth-form"]').should('be.visible')
+    cy.get('[data-testid="sign-up-encouragement-message"]').should('not.exist')
+    cy.get('[data-testid="kong-auth-login-sso"]').should('exist')
+  })
+
+
   it('does not show Login with SSO button', () => {
-    cy.mockPrivatePortal({ oidc_auth_enabled: false })
+    cy.mockPrivatePortal({ oidc_auth_enabled: false, saml_auth_enabled: false })
 
     cy.visit('/', { useOriginalFn: true })
     cy.location('pathname').should('equal', '/login')

--- a/cypress/e2e/specs/register.spec.ts
+++ b/cypress/e2e/specs/register.spec.ts
@@ -63,7 +63,17 @@ describe('Register Page', () => {
       cy.get('[data-testid="kong-auth-login-sso"]').should('not.exist')
     })
     it('redirects to login (with SSO) when basic auth disabled', () => {
-      cy.mockPrivatePortal({ basic_auth_enabled: false, oidc_auth_enabled: true })
+      cy.mockPrivatePortal({ basic_auth_enabled: false, oidc_auth_enabled: true, saml_auth_enabled: false })
+
+      cy.visit('/', { useOriginalFn: true })
+      cy.location('pathname').should('equal', '/login')
+      cy.get('[data-testid="auth-form"]').should('be.visible')
+      cy.get('[data-testid="sign-up-encouragement-message"]').should('not.exist')
+      cy.get('[data-testid="kong-auth-login-sso"]').should('exist')
+    })
+
+    it('redirects to login (with SSO - SAML) when basic auth disabled', () => {
+      cy.mockPrivatePortal({ basic_auth_enabled: false, oidc_auth_enabled: false, saml_auth_enabled: true })
 
       cy.visit('/', { useOriginalFn: true })
       cy.location('pathname').should('equal', '/login')

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ import useToaster from './composables/useToaster'
 import usePortalApi from './hooks/usePortalApi'
 import { createRedirectHandler } from './helpers/auth'
 import portalAnalyticsBridge from '@kong-ui-public/portal-analytics-bridge'
+import { PortalContext } from '@kong/sdk-portal-js'
 
 /**
  * Initialize application
@@ -66,18 +67,20 @@ async function init () {
       featureset_id: featuresetId,
       feature_set: featureSet,
       oidc_auth_enabled: oidcAuthEnabled,
+      saml_auth_enabled: samlAuthEnabled,
       is_public: isPublic,
       basic_auth_enabled: basicAuthEnabled,
       rbac_enabled: isRbacEnabled,
       allowed_time_period: allowedTimePeriod,
       canonical_domain: canonicalDomain
-    } = portalContext.data
+    } = portalContext.data as PortalContext & { saml_auth_enabled: boolean }
 
     if (isPublic === false) {
       portalApiV2.value.updateClientWithCredentials()
     }
 
-    const authClientConfig = { basicAuthEnabled, oidcAuthEnabled }
+    // SAML Auth enabled comes on a different portal context property, but is handled the same as OIDC by the Auth Client
+    const authClientConfig = { basicAuthEnabled, oidcAuthEnabled: oidcAuthEnabled || samlAuthEnabled }
 
     setPortalData({ portalId, orgId, authClientConfig, featuresetId, featureSet, isPublic, isRbacEnabled, allowedTimePeriod, canonicalDomain })
     setSession(session)


### PR DESCRIPTION
This PR adds logic to read `saml_auth_enabled` to determine if the SSO login button should be enabled