### PR TITLE
chore(ci): use latest ubuntu for sast job

### DIFF
--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   semgrep:
     name: SAST
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       # required for all workflows
       security-events: write


### PR DESCRIPTION
This job was not running because it was on an unsupported runner version